### PR TITLE
feat(#3): doc returns document

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-runtime</artifactId>
-      <version>0.50.0</version>
+      <version>0.50.1</version>
     </dependency>
   </dependencies>
   <build>
@@ -109,13 +109,11 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.50.0</version>
+        <version>0.50.1</version>
         <configuration>
           <foreign>${project.build.directory}/eo-foreign.csv</foreign>
           <foreignFormat>csv</foreignFormat>
           <failOnWarning>false</failOnWarning>
-          <offline>true</offline>
-          <unphiOutputDir>${project.build.directory}/eo/unphi</unphiOutputDir>
         </configuration>
         <executions>
           <execution>
@@ -133,8 +131,9 @@ SOFTWARE.
               <goal>unspile</goal>
             </goals>
             <configuration>
-              <withRuntimeDependency>false</withRuntimeDependency>
-              <placeBinariesThatHaveSources>true</placeBinariesThatHaveSources>
+              <keepBinaries>
+                <glob>EOorg/EOeolang/EOdom/**</glob>
+              </keepBinaries>
             </configuration>
           </execution>
           <execution>
@@ -161,7 +160,7 @@ SOFTWARE.
               <addTestSourcesRoot>true</addTestSourcesRoot>
               <failOnWarning>false</failOnWarning>
               <generatedDir>${project.build.directory}/generated-test-sources</generatedDir>
-              <withRuntimeDependency>false</withRuntimeDependency>
+              <withRuntimeDependency>true</withRuntimeDependency>
               <placeBinariesThatHaveSources>true</placeBinariesThatHaveSources>
             </configuration>
           </execution>

--- a/src/main/eo/org/eolang/dom/doc.eo
+++ b/src/main/eo/org/eolang/dom/doc.eo
@@ -27,5 +27,6 @@
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
 
-# The doc object allows you to create XML tree-based documents.
-[] > doc /org.eolang.dom
+# The doc object allows you to create XML tree-based documents. Serves as
+# an entry-point into the XML-based document's content.
+[data] > doc /org.eolang.dom

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc.java
@@ -27,9 +27,9 @@
  */
 package EOorg.EOeolang.EOdom; // NOPMD
 
-import java.nio.charset.StandardCharsets;
 import org.eolang.AtVoid;
 import org.eolang.Atom;
+import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -53,8 +53,8 @@ public final class EOdoc extends PhDefault implements Atom {
 
     @Override
     public Phi lambda() {
-        return new PhDefault(
-            new Dataized(this.take("data")).asString().getBytes(StandardCharsets.UTF_8)
+        return new Data.ToPhi(
+            new Dataized(this.take("data")).asString()
         );
     }
 }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc.java
@@ -27,21 +27,34 @@
  */
 package EOorg.EOeolang.EOdom; // NOPMD
 
+import java.nio.charset.StandardCharsets;
+import org.eolang.AtVoid;
 import org.eolang.Atom;
+import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
 
 /**
- * Document.
+ * Document atom.
  * @since 0.0.0
  * @checkstyle TypeNameCheck (5 lines)
  */
 @XmirObject(oname = "doc")
 public final class EOdoc extends PhDefault implements Atom {
 
+    /**
+     * Ctor.
+     */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+    public EOdoc() {
+        this.add("data", new AtVoid("data"));
+    }
+
     @Override
     public Phi lambda() {
-        return new PhDefault();
+        return new PhDefault(
+            new Dataized(this.take("data")).asString().getBytes(StandardCharsets.UTF_8)
+        );
     }
 }

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -20,6 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.dom.doc
++architect yegor256@gmail.com
++home https://github.com/h1alexbel/eo-dom
 +tests
++package org.eolang.dom
++version 0.0.0
++unlint broken-ref
 
-[] > creates-document
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > compares-two-bools
+  eq. > @
+    doc "<program/>"
+    "<program/>"

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -27,7 +27,11 @@
  */
 package EOorg.EOeolang.EOdom; // NOPMD
 
-import org.junit.jupiter.api.Assertions;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,9 +43,12 @@ final class EOdocTest {
 
     @Test
     void createsDocument() {
-        Assertions.assertDoesNotThrow(
-            () -> new EOdoc().lambda(),
-            "EOdoc should not throw exception"
+        final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
+        doc.put("data", new Data.ToPhi("<program/>"));
+        MatcherAssert.assertThat(
+            "Document was not created, but it should",
+            new Dataized(doc).asString(),
+            Matchers.equalTo("<program/>")
         );
     }
 }


### PR DESCRIPTION
In this PR I've setup `doc` object.

see #3

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the `doc` object in the `org.eolang.dom` package by refining its functionality, updating versioning, and improving unit tests to ensure proper document creation.

### Detailed summary
- Updated version to `0.0.0` for `doc` in `src/main/eo/org/eolang/dom/doc.eo`.
- Modified `doc` to accept `data` as input.
- Added metadata (alias, architect, home, package, version, unlint) in `doc-tests.eo`.
- Introduced a new test `compares-two-bools` in `doc-tests.eo`.
- Revised `createsDocument` test to use `MatcherAssert` for validation.
- Enhanced `EOdoc` class in `EOdoc.java` with a constructor initializing `data`.
- Updated `lambda()` method in `EOdoc` to return `Data.ToPhi` representation.
- Bumped version from `0.50.0` to `0.50.1` in `pom.xml` for dependencies and plugin.
- Adjusted Maven plugin configuration, including changes to `keepBinaries` and `withRuntimeDependency`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->