### PR TITLE
feat(#3): doc with XMLDocument inside

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,17 @@ SOFTWARE.
       <artifactId>eo-runtime</artifactId>
       <version>0.51.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.jcabi</groupId>
+      <artifactId>jcabi-xml</artifactId>
+      <version>0.33.5</version>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.saxon</groupId>
+      <artifactId>Saxon-HE</artifactId>
+      <version>12.5</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc.java
@@ -27,9 +27,9 @@
  */
 package EOorg.EOeolang.EOdom; // NOPMD
 
+import com.jcabi.xml.XMLDocument;
 import org.eolang.AtVoid;
 import org.eolang.Atom;
-import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -53,8 +53,12 @@ public final class EOdoc extends PhDefault implements Atom {
 
     @Override
     public Phi lambda() {
-        return new Data.ToPhi(
-            new Dataized(this.take("data")).asString()
+        return new ToPhi(
+            new XMLDocument(
+                new Dataized(
+                    this.take("data")
+                ).asString()
+            ).toString()
         );
     }
 }

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -29,7 +29,7 @@
 +unlint broken-ref
 
 # This unit test is supposed to check the functionality of the corresponding object.
-[] > compares-two-bools
+[] > creates-simple-document
   eq. > @
     doc "<program/>"
-    "<program/>"
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<program/>\n"

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -60,7 +60,7 @@ final class EOdocTest {
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () -> new Dataized(doc).asString(),
-            () -> "Error should be thrown, if XML is invalid"
+            () -> "Error should be thrown, since XML is invalid"
         );
     }
 }

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -56,7 +56,7 @@ final class EOdocTest {
     @Test
     void throwsErrorIfInvalidXmlPassed() {
         final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
-        doc.put("data", new Data.ToPhi("program"));
+        doc.put("data", new Data.ToPhi("broken"));
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () -> new Dataized(doc).asString(),

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -32,6 +32,7 @@ import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -48,7 +49,18 @@ final class EOdocTest {
         MatcherAssert.assertThat(
             "Document was not created, but it should",
             new Dataized(doc).asString(),
-            Matchers.equalTo("<program/>")
+            Matchers.equalTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<program/>\n")
+        );
+    }
+
+    @Test
+    void throwsErrorIfInvalidXmlPassed() {
+        final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
+        doc.put("data", new Data.ToPhi("program"));
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new Dataized(doc).asString(),
+            () -> "Error should be thrown, if XML is invalid"
         );
     }
 }


### PR DESCRIPTION
In this PR, I've added `XMLDocument` allocation inside `doc` object.

see #3

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the XML document creation functionality in the `EOdoc` class and its corresponding tests. It updates the expected output format and adds error handling for invalid XML inputs.

### Detailed summary
- Renamed the test from `compares-two-bools` to `creates-simple-document`.
- Updated expected XML output to include XML declaration.
- Added dependencies for `jcabi-xml` and `Saxon-HE` in `pom.xml`.
- Modified `lambda` method in `EOdoc` to return XML formatted string.
- Added a new test to check for exceptions when invalid XML is provided.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->