### PR TITLE
feat(#8): `doc.elem` via simple xnav

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@ SOFTWARE.
       <version>0.33.5</version>
     </dependency>
     <dependency>
+      <groupId>com.github.volodya-lombrozo</groupId>
+      <artifactId>xnav</artifactId>
+      <version>0.1.10</version>
+    </dependency>
+    <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
       <version>12.5</version>

--- a/src/main/eo/org/eolang/dom/doc.eo
+++ b/src/main/eo/org/eolang/dom/doc.eo
@@ -36,3 +36,4 @@
   # Serialized data.
   [serialized] > xml
     [] > as-string /org.eolang.string
+    [ename] > elem /org.eolang.dom.doc.xml

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
@@ -25,7 +25,7 @@
  * @checkstyle PackageNameCheck (4 lines)
  * @checkstyle TrailingCommentCheck (3 lines)
  */
-package EOorg.EOeolang.EOdom;
+package EOorg.EOeolang.EOdom; // NOPMD
 
 import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XMLDocument;
@@ -39,22 +39,24 @@ import org.eolang.Phi;
 import org.eolang.XmirObject;
 
 /**
- * Element from XML document
+ * Element from XML document.
  * @since 0.0.0
- * @checkstyle TypeNameCheck (5 lines)
  * @todo #8:45min Implement element navigation without xnav.
  *  Currently, element extraction is implemented via xnav. We should implement
  *  the element navigation without any external dependencies.
  * @todo #8:45min Return proper error, if element not found.
  *  We should return proper error, if element is not found. Currently, the
  *  default EO error message will be thrown. Don't forget to add unit test.
+ * @checkstyle TypeNameCheck (5 lines)
  */
+@SuppressWarnings("PMD.AvoidDollarSigns")
 @XmirObject(oname = "doc.xml.elem")
 public final class EOdoc$EOxml$EOelem extends PhDefault implements Atom {
 
     /**
      * Ctor.
      */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public EOdoc$EOxml$EOelem() {
         this.add("ename", new AtVoid("ename"));
     }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package EOorg.EOeolang.EOdom;
+
+import org.eolang.AtVoid;
+import org.eolang.Atom;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * Element from XML document
+ * @since 0.0.0
+ */
+@XmirObject(oname = "doc.xml.elem")
+public final class EOdoc$EOxml$EOelem extends PhDefault implements Atom {
+
+    /**
+     * Ctor.
+     */
+    public EOdoc$EOxml$EOelem() {
+        this.add("ename", new AtVoid("ename"));
+    }
+
+    @Override
+    public Phi lambda() {
+        return new Data.ToPhi(new Dataized(this.take("ename")).asString());
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
@@ -42,6 +42,12 @@ import org.eolang.XmirObject;
  * Element from XML document
  * @since 0.0.0
  * @checkstyle TypeNameCheck (5 lines)
+ * @todo #8:45min Implement element navigation without xnav.
+ *  Currently, element extraction is implemented via xnav. We should implement
+ *  the element navigation without any external dependencies.
+ * @todo #8:45min Return proper error, if element not found.
+ *  We should return proper error, if element is not found. Currently, the
+ *  default EO error message will be thrown. Don't forget to add unit test.
  */
 @XmirObject(oname = "doc.xml.elem")
 public final class EOdoc$EOxml$EOelem extends PhDefault implements Atom {

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
@@ -21,10 +21,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
 package EOorg.EOeolang.EOdom;
 
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XMLDocument;
 import org.eolang.AtVoid;
 import org.eolang.Atom;
+import org.eolang.Attr;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
@@ -34,6 +41,7 @@ import org.eolang.XmirObject;
 /**
  * Element from XML document
  * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
  */
 @XmirObject(oname = "doc.xml.elem")
 public final class EOdoc$EOxml$EOelem extends PhDefault implements Atom {
@@ -47,6 +55,12 @@ public final class EOdoc$EOxml$EOelem extends PhDefault implements Atom {
 
     @Override
     public Phi lambda() {
-        return new Data.ToPhi(new Dataized(this.take("ename")).asString());
+        return new Data.ToPhi(
+            new XMLDocument(
+                new Xnav(
+                    new Dataized(this.take(Attr.RHO).take("serialized")).asString()
+                ).element(new Dataized(this.take("ename")).asString()).node()
+            ).toString().getBytes()
+        );
     }
 }

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -33,3 +33,10 @@
   eq. > @
     (doc "<program/>").as-string
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<program/>\n"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > finds-element-in-document
+  ((doc "<program/>").elem "program") > elem
+  eq. > @
+    elem
+    "<program/>"

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -36,7 +36,8 @@
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > finds-element-in-document
-  ((doc "<program/>").elem "program") > elem
   eq. > @
-    elem
-    "<program/>"
+    doc
+      "<program/>"
+    .elem "program"
+    "<program/>\n"

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -64,4 +64,17 @@ final class EOdocTest {
             () -> "Error should be thrown, since XML is invalid"
         );
     }
+
+    @Test
+    void findsElementInDocument() {
+        final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
+        doc.put("data", new Data.ToPhi("<program/>"));
+        final Phi elem = doc.take("elem");
+        elem.put("ename", new Data.ToPhi("test"));
+        MatcherAssert.assertThat(
+            "Element result doesn't match with expected",
+            new Dataized(elem).asString(),
+            Matchers.equalTo("test")
+        );
+    }
 }

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -68,13 +68,13 @@ final class EOdocTest {
     @Test
     void findsElementInDocument() {
         final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
-        doc.put("data", new Data.ToPhi("<program/>"));
+        doc.put("data", new Data.ToPhi("<program><test>here</test></program>"));
         final Phi elem = doc.take("elem");
-        elem.put("ename", new Data.ToPhi("test"));
+        elem.put("ename", new Data.ToPhi("program"));
         MatcherAssert.assertThat(
             "Element result doesn't match with expected",
             new Dataized(elem).asString(),
-            Matchers.equalTo("test")
+            Matchers.equalTo("<program>\n   <test>here</test>\n</program>\n")
         );
     }
 }

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -77,4 +77,17 @@ final class EOdocTest {
             Matchers.equalTo("<program>\n   <test>here</test>\n</program>\n")
         );
     }
+
+    @Test
+    void findsElementInEmptyRoot() {
+        final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
+        doc.put("data", new Data.ToPhi("<program/>"));
+        final Phi elem = doc.take("elem");
+        elem.put("ename", new Data.ToPhi("program"));
+        MatcherAssert.assertThat(
+            "Element result doesn't match with expected",
+            new Dataized(elem).asString(),
+            Matchers.equalTo("<program/>\n")
+        );
+    }
 }


### PR DESCRIPTION
In this PR I've implemented `elem` atom for doc object. Elem retrieves element from the document by element name.

closes #8
History:
- **feat(#8): start**
- **feat(#8): start**
- **feat(#8): nav**
- **feat(#8): puzzles**
- **feat(#8): passes**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces functionality for XML element extraction in the `org.eolang.dom.doc` module. It adds new tests, updates the `doc` object to handle XML elements, and includes a new dependency for XML navigation.

### Detailed summary
- Added `elem` functionality to `doc` in `src/main/eo/org/eolang/dom/doc.eo`.
- Introduced unit tests for element extraction in `src/test/eo/org/eolang/dom/doc-tests.eo`.
- Implemented `findsElementInDocument` and `findsElementInEmptyRoot` tests in `src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java`.
- Updated `pom.xml` with a new dependency on `xnav`.
- Created `EOdoc$EOxml$EOelem` class for XML element handling in `src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->