### PR TITLE
feat(#22): doc uses XmlNode implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,14 +89,9 @@ SOFTWARE.
       <version>0.51.5</version>
     </dependency>
     <dependency>
-      <groupId>com.jcabi</groupId>
-      <artifactId>jcabi-xml</artifactId>
-      <version>0.33.5</version>
-    </dependency>
-    <dependency>
-      <groupId>com.github.volodya-lombrozo</groupId>
-      <artifactId>xnav</artifactId>
-      <version>0.1.10</version>
+      <groupId>org.cactoos</groupId>
+      <artifactId>cactoos</artifactId>
+      <version>0.56.1</version>
     </dependency>
     <dependency>
       <groupId>net.sf.saxon</groupId>

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
@@ -27,8 +27,6 @@
  */
 package EOorg.EOeolang.EOdom; // NOPMD
 
-import com.github.lombrozo.xnav.Xnav;
-import com.jcabi.xml.XMLDocument;
 import org.eolang.AtVoid;
 import org.eolang.Atom;
 import org.eolang.Attr;
@@ -64,11 +62,9 @@ public final class EOdoc$EOxml$EOelem extends PhDefault implements Atom {
     @Override
     public Phi lambda() {
         return new Data.ToPhi(
-            new XMLDocument(
-                new Xnav(
-                    new Dataized(this.take(Attr.RHO).take("serialized")).asString()
-                ).element(new Dataized(this.take("ename")).asString()).node()
-            ).toString().getBytes()
+            new XmlNode.Default(new Dataized(this.take(Attr.RHO).take("serialized")).asString())
+                .elem(new Dataized(this.take("ename")).asString())
+                .asString().getBytes()
         );
     }
 }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
@@ -39,9 +39,6 @@ import org.eolang.XmirObject;
 /**
  * Element from XML document.
  * @since 0.0.0
- * @todo #8:45min Implement element navigation without xnav.
- *  Currently, element extraction is implemented via xnav. We should implement
- *  the element navigation without any external dependencies.
  * @todo #8:45min Return proper error, if element not found.
  *  We should return proper error, if element is not found. Currently, the
  *  default EO error message will be thrown. Don't forget to add unit test.

--- a/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
@@ -52,6 +52,8 @@ public interface XmlNode {
      */
     XmlNode elem(String name);
 
+    String attr(String aname);
+
     /**
      * Serialize node as string.
      *
@@ -72,6 +74,16 @@ public interface XmlNode {
                 String.format(
                     "There is no '%s' element inside, since node itself is empty!",
                     name
+                )
+            );
+        }
+
+        @Override
+        public String attr(final String aname) {
+            throw new IllegalStateException(
+                String.format(
+                    "There is no '%s' attribute inside, since node itself is empty!",
+                    aname
                 )
             );
         }
@@ -124,6 +136,17 @@ public interface XmlNode {
                 }
             }
             return result;
+        }
+
+        @Override
+        public String attr(final String aname) {
+            final String found = this.base.getAttribute(aname);
+            if (found.isBlank()) {
+                throw new IllegalArgumentException(
+                    String.format("Attribute '%s' was not found in the node", aname)
+                );
+            }
+            return found;
         }
 
         @Override

--- a/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
@@ -54,6 +54,8 @@ public interface XmlNode {
 
     String attr(String aname);
 
+    String text();
+
     /**
      * Serialize node as string.
      *
@@ -72,7 +74,7 @@ public interface XmlNode {
         public XmlNode elem(final String name) {
             throw new IllegalStateException(
                 String.format(
-                    "There is no '%s' element inside, since node itself is empty!",
+                    "Cannot read '%s' element inside, since node itself is empty!",
                     name
                 )
             );
@@ -82,9 +84,16 @@ public interface XmlNode {
         public String attr(final String aname) {
             throw new IllegalStateException(
                 String.format(
-                    "There is no '%s' attribute inside, since node itself is empty!",
+                    "Cannot read '%s' attribute inside, since node itself is empty!",
                     aname
                 )
+            );
+        }
+
+        @Override
+        public String text() {
+            throw new IllegalStateException(
+                "Cannot read text inside, since node itself is empty!"
             );
         }
 
@@ -147,6 +156,11 @@ public interface XmlNode {
                 );
             }
             return found;
+        }
+
+        @Override
+        public String text() {
+            return this.base.getTextContent();
         }
 
         @Override

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -40,4 +40,12 @@
     doc
       "<program/>"
     .elem "program"
-    "<program/>\n"
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><program/>"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > finds-child-element
+  eq. > @
+    doc
+      "<program><test>here</test></program>"
+    .elem "test"
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>here</test>"

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -74,7 +74,9 @@ final class EOdocTest {
         MatcherAssert.assertThat(
             "Element result doesn't match with expected",
             new Dataized(elem).asString(),
-            Matchers.equalTo("<program>\n   <test>here</test>\n</program>\n")
+            Matchers.equalTo(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><program><test>here</test></program>"
+            )
         );
     }
 
@@ -87,7 +89,24 @@ final class EOdocTest {
         MatcherAssert.assertThat(
             "Element result doesn't match with expected",
             new Dataized(elem).asString(),
-            Matchers.equalTo("<program/>\n")
+            Matchers.equalTo(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><program/>"
+            )
+        );
+    }
+
+    @Test
+    void findsChildElement() {
+        final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
+        doc.put("data", new Data.ToPhi("<program><test>here</test></program>"));
+        final Phi elem = doc.take("elem");
+        elem.put("ename", new Data.ToPhi("test"));
+        MatcherAssert.assertThat(
+            "Element result doesn't match with expected",
+            new Dataized(elem).asString(),
+            Matchers.equalTo(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>here</test>"
+            )
         );
     }
 }

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -45,31 +45,25 @@ final class EOdocTest {
 
     @Test
     void createsDocument() {
-        final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
-        doc.put("data", new Data.ToPhi("<program/>"));
         MatcherAssert.assertThat(
             "Document was not created, but it should",
-            new Dataized(doc.take("serialized")).asString(),
+            new Dataized(this.document("<program/>").take("serialized")).asString(),
             Matchers.equalTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?><program/>")
         );
     }
 
     @Test
     void throwsErrorIfInvalidXmlPassed() {
-        final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
-        doc.put("data", new Data.ToPhi("broken"));
         Assertions.assertThrows(
             EOerror.ExError.class,
-            () -> new Dataized(doc.take("xml")).asString(),
+            () -> new Dataized(this.document("broken").take("xml")).asString(),
             () -> "Error should be thrown, since XML is invalid"
         );
     }
 
     @Test
     void findsElementInDocument() {
-        final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
-        doc.put("data", new Data.ToPhi("<program><test>here</test></program>"));
-        final Phi elem = doc.take("elem");
+        final Phi elem = this.document("<program><test>here</test></program>").take("elem");
         elem.put("ename", new Data.ToPhi("program"));
         MatcherAssert.assertThat(
             "Element result doesn't match with expected",
@@ -82,9 +76,7 @@ final class EOdocTest {
 
     @Test
     void findsElementInEmptyRoot() {
-        final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
-        doc.put("data", new Data.ToPhi("<program/>"));
-        final Phi elem = doc.take("elem");
+        final Phi elem = this.document("<program/>").take("elem");
         elem.put("ename", new Data.ToPhi("program"));
         MatcherAssert.assertThat(
             "Element result doesn't match with expected",
@@ -97,9 +89,7 @@ final class EOdocTest {
 
     @Test
     void findsChildElement() {
-        final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
-        doc.put("data", new Data.ToPhi("<program><test>here</test></program>"));
-        final Phi elem = doc.take("elem");
+        final Phi elem = this.document("<program><test>here</test></program>").take("elem");
         elem.put("ename", new Data.ToPhi("test"));
         MatcherAssert.assertThat(
             "Element result doesn't match with expected",
@@ -108,5 +98,11 @@ final class EOdocTest {
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>here</test>"
             )
         );
+    }
+
+    private Phi document(final String xml) {
+        final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
+        doc.put("data", new Data.ToPhi(xml));
+        return doc;
     }
 }

--- a/src/test/java/EOorg/EOeolang/EOdom/XmlNodeTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/XmlNodeTest.java
@@ -69,7 +69,7 @@ final class XmlNodeTest {
             "Exception should be thrown, but it was not",
             () -> new XmlNode.Default("<program/>").elem("f").elem("bar"),
             new Throws<>(
-                "There is no 'bar' element inside, since node itself is empty!",
+                "Cannot read 'bar' element inside, since node itself is empty!",
                 IllegalStateException.class
             )
         );
@@ -151,7 +151,7 @@ final class XmlNodeTest {
             "Exception should be thrown, but it was not",
             () -> new XmlNode.Default("<program/>").elem("f").attr("x"),
             new Throws<>(
-                "There is no 'x' attribute inside, since node itself is empty!",
+                "Cannot read 'x' attribute inside, since node itself is empty!",
                 IllegalStateException.class
             )
         );

--- a/src/test/java/EOorg/EOeolang/EOdom/XmlNodeTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/XmlNodeTest.java
@@ -40,7 +40,7 @@ import org.llorllale.cactoos.matchers.Throws;
 final class XmlNodeTest {
 
     @Test
-    void parsesDocumentFromString() throws Exception {
+    void parsesDocumentFromString() {
         MatcherAssert.assertThat(
             "Parsed document doesn't match with expected",
             new XmlNode.Default("<program><test foo=\"f\">bar</test></program>")
@@ -52,7 +52,7 @@ final class XmlNodeTest {
     }
 
     @Test
-    void parsesNodeFromNextElement() throws Exception {
+    void parsesNodeFromNextElement() {
         MatcherAssert.assertThat(
             "Parsed document doesn't match with expected",
             new XmlNode.Default("<program><test foo=\"f\">bar</test></program>")
@@ -66,7 +66,7 @@ final class XmlNodeTest {
     @Test
     void throwsOnEmptyNodeInElementChain() {
         MatcherAssert.assertThat(
-            "Exception should be thrown, but its not",
+            "Exception should be thrown, but it was not",
             () -> new XmlNode.Default("<program/>").elem("f").elem("bar"),
             new Throws<>(
                 "There is no 'bar' element inside, since node itself is empty!",
@@ -78,9 +78,47 @@ final class XmlNodeTest {
     @Test
     void throwsOnPrintingEmptyNode() {
         MatcherAssert.assertThat(
-            "Exception should be thrown, but its not",
+            "Exception should be thrown, but it was not",
             () -> new XmlNode.Default("<program/>").elem("f").asString(),
             new Throws<>("Node is empty", IllegalStateException.class)
         );
     }
+
+    @Test
+    void findsAttribute() {
+        MatcherAssert.assertThat(
+            "Attribute value does not match with expected",
+            new XmlNode.Default("<program><test foo=\"f\">bar</test></program>")
+                .elem("test").attr("foo"),
+            Matchers.equalTo("f")
+        );
+    }
+
+    @Test
+    void throwsOnFindingAttributeInEmptyNode() {
+        MatcherAssert.assertThat(
+            "Exception should be thrown, but it was not",
+            () -> new XmlNode.Default("<program/>").elem("f").attr("x"),
+            new Throws<>(
+                "There is no 'x' attribute inside, since node itself is empty!",
+                IllegalStateException.class
+            )
+        );
+    }
+
+    @Test
+    void throwsOnNonExistingAttribute() {
+        MatcherAssert.assertThat(
+            "Exception was not thrown, though attribute does not exists",
+            () -> new XmlNode.Default("<program/>").attr("b"),
+            new Throws<>("Attribute 'b' was not found in the node", IllegalArgumentException.class)
+        );
+    }
+
+    // (doc "<your xml goes here>") > xml
+    // xml.as-string
+    // (((xml.elem "a").elem "b").elem "c") > c
+    // c.as-string
+    // c.attr "xa" > xa
+    // xa
 }

--- a/src/test/java/EOorg/EOeolang/EOdom/XmlNodeTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/XmlNodeTest.java
@@ -37,6 +37,7 @@ import org.llorllale.cactoos.matchers.Throws;
  *
  * @since 0.0.0
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class XmlNodeTest {
 
     @Test
@@ -137,7 +138,7 @@ final class XmlNodeTest {
     void throwsOnFindingTextInEmptyNode() {
         MatcherAssert.assertThat(
             "Exception was not thrown",
-            () -> new XmlNode.Default("<program/>").elem("f").text(),
+            () -> new XmlNode.Default("<foo/>").elem("f").text(),
             new Throws<>(
                 "Cannot read text inside, since node itself is empty!",
                 IllegalStateException.class
@@ -149,7 +150,7 @@ final class XmlNodeTest {
     void throwsOnFindingAttributeInEmptyNode() {
         MatcherAssert.assertThat(
             "Exception should be thrown, but it was not",
-            () -> new XmlNode.Default("<program/>").elem("f").attr("x"),
+            () -> new XmlNode.Default("<bar/>").elem("f").attr("x"),
             new Throws<>(
                 "Cannot read 'x' attribute inside, since node itself is empty!",
                 IllegalStateException.class

--- a/src/test/java/EOorg/EOeolang/EOdom/XmlNodeTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/XmlNodeTest.java
@@ -95,6 +95,57 @@ final class XmlNodeTest {
     }
 
     @Test
+    void throwsOnNonExistingAttribute() {
+        MatcherAssert.assertThat(
+            "Exception was not thrown, though attribute does not exists",
+            () -> new XmlNode.Default("<program/>").attr("b"),
+            new Throws<>("Attribute 'b' was not found in the node", IllegalArgumentException.class)
+        );
+    }
+
+    @Test
+    void returnsTextInside() {
+        MatcherAssert.assertThat(
+            "Text node does not match with expected",
+            new XmlNode.Default("<program>foo</program>").text(),
+            Matchers.equalTo("foo")
+        );
+    }
+
+    @Test
+    void returnsTextAfterChaining() {
+        MatcherAssert.assertThat(
+            "Output does not match with expected",
+            new XmlNode.Default("<program><test foo=\"f\">bar</test></program>")
+                .elem("program")
+                .elem("test")
+                .text(),
+            Matchers.equalTo("bar")
+        );
+    }
+
+    @Test
+    void returnsEmptyText() {
+        MatcherAssert.assertThat(
+            "Text should be empty",
+            new XmlNode.Default("<program/>").text(),
+            Matchers.emptyString()
+        );
+    }
+
+    @Test
+    void throwsOnFindingTextInEmptyNode() {
+        MatcherAssert.assertThat(
+            "Exception was not thrown",
+            () -> new XmlNode.Default("<program/>").elem("f").text(),
+            new Throws<>(
+                "Cannot read text inside, since node itself is empty!",
+                IllegalStateException.class
+            )
+        );
+    }
+
+    @Test
     void throwsOnFindingAttributeInEmptyNode() {
         MatcherAssert.assertThat(
             "Exception should be thrown, but it was not",
@@ -105,20 +156,4 @@ final class XmlNodeTest {
             )
         );
     }
-
-    @Test
-    void throwsOnNonExistingAttribute() {
-        MatcherAssert.assertThat(
-            "Exception was not thrown, though attribute does not exists",
-            () -> new XmlNode.Default("<program/>").attr("b"),
-            new Throws<>("Attribute 'b' was not found in the node", IllegalArgumentException.class)
-        );
-    }
-
-    // (doc "<your xml goes here>") > xml
-    // xml.as-string
-    // (((xml.elem "a").elem "b").elem "c") > c
-    // c.as-string
-    // c.attr "xa" > xa
-    // xa
 }


### PR DESCRIPTION
In this PR I've replaced `XMLDocument` and `Xnav` with custom implementation of `XmlNode`, that is now used in `doc` atom.

closes #22
History:
- **feat(#22): attr**
- **feat(#22): text**
- **feat(#22): works with .elem**
- **feat(#22): clean for qulice**
- **feat(#22): puzzle off**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving XML document handling in the `Eolang` project by replacing external dependencies, enhancing error handling, and adding new functionalities for XML element navigation and attributes.

### Detailed summary
- Updated XML serialization format in `doc-tests.eo`.
- Replaced `jcabi-xml` and `xnav` dependencies with `cactoos` in `pom.xml`.
- Enhanced `EOdoc$EOxml$EOelem` to use `XmlNode` for element extraction.
- Added error handling for empty nodes in `XmlNode`.
- Introduced methods for attribute and text retrieval in `XmlNode`.
- Updated unit tests in `EOdocTest.java` and `XmlNodeTest.java` to reflect changes and add new tests for attributes and text.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->