### PR TITLE
feat(#9): doc.attr

### DIFF
--- a/src/main/eo/org/eolang/dom/doc.eo
+++ b/src/main/eo/org/eolang/dom/doc.eo
@@ -37,3 +37,4 @@
   [serialized] > xml
     [] > as-string /org.eolang.string
     [ename] > elem /org.eolang.dom.doc.xml
+    [aname] > attr /org.eolang.dom.doc.xml

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOattr.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOattr.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom; // NOPMD
+
+import org.eolang.AtVoid;
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+
+/**
+ * Attribute in XML node.
+ *
+ * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
+ */
+@SuppressWarnings("PMD.AvoidDollarSigns")
+public final class EOdoc$EOxml$EOattr extends PhDefault implements Atom {
+
+    /**
+     * Ctor.
+     */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+    public EOdoc$EOxml$EOattr() {
+        this.add("aname", new AtVoid("aname"));
+    }
+
+    @Override
+    public Phi lambda() {
+        return new Data.ToPhi(
+            new XmlNode.Default(new Dataized(this.take(Attr.RHO).take("serialized")).asString())
+                .attr(new Dataized(this.take("aname")).asString())
+                .getBytes()
+        );
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
@@ -52,8 +52,17 @@ public interface XmlNode {
      */
     XmlNode elem(String name);
 
+    /**
+     * Attr.
+     * @param aname Attribute name
+     * @return Attribute value of the node
+     */
     String attr(String aname);
 
+    /**
+     * Text inside.
+     * @return Text inside the node
+     */
     String text();
 
     /**

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -49,3 +49,11 @@
       "<program><test>here</test></program>"
     .elem "test"
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>here</test>"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > finds-attribute-inside-node
+  eq. > @
+    doc
+      "<foo bar=\"ax\"></foo>"
+    .attr "bar"
+    "ax"

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -34,6 +34,7 @@ import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -97,6 +98,42 @@ final class EOdocTest {
             Matchers.equalTo(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>here</test>"
             )
+        );
+    }
+
+    @Test
+    void returnsAttributeInsideNode() {
+        final Phi attr = this.document("<program test=\"f\"/>").take("attr");
+        attr.put("aname", new Data.ToPhi("test"));
+        MatcherAssert.assertThat(
+            "Value does not match with expected",
+            new Dataized(attr).asString(),
+            Matchers.equalTo("f")
+        );
+    }
+
+    /**
+     * Returns attribute inside child node.
+     * @todo #9:45min Enable this test on attribute fetching after child object
+     *  cascading will be implemented. Currenlty, we can't take `attr` object from
+     *  `elem` object. It should be possible to do this in EO:
+     *  <pre>
+     *  {@code
+     *  ((doc "...").elem "f").attr "x"
+     *  }
+     *  </pre>
+     */
+    @Disabled
+    @Test
+    void returnsAttributeInsideChildNode() {
+        final Phi elem = this.document("<foo><bar x=\"ttt\"></bar></foo>").take("elem");
+        elem.put("ename", new Data.ToPhi("bar"));
+        final Phi attr = elem.take("attr");
+        attr.put("aname", new Data.ToPhi("x"));
+        MatcherAssert.assertThat(
+            "Value does not match with expected",
+            new Dataized(attr).asString(),
+            Matchers.equalTo("ttt")
         );
     }
 


### PR DESCRIPTION
In this PR I've added new child object to `doc`: `attr`, implemented via `EOdoc$EOxml$EOattr` atom.

closes #9