### PR TITLE
feat(#10): `doc.text`

### DIFF
--- a/src/main/eo/org/eolang/dom/doc.eo
+++ b/src/main/eo/org/eolang/dom/doc.eo
@@ -38,3 +38,4 @@
     [] > as-string /org.eolang.string
     [ename] > elem /org.eolang.dom.doc.xml
     [aname] > attr /org.eolang.dom.doc.xml
+    [] > text /org.eolang.string

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOtext.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOtext.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom; // NOPMD
+
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+
+/**
+ * Text inside XML node.
+ * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
+ */
+@SuppressWarnings("PMD.AvoidDollarSigns")
+public final class EOdoc$EOxml$EOtext extends PhDefault implements Atom {
+
+    @Override
+    public Phi lambda() {
+        return new Data.ToPhi(
+            new XmlNode.Default(new Dataized(this.take(Attr.RHO).take("serialized")).asString())
+                .text().getBytes()
+        );
+    }
+}

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -57,3 +57,9 @@
       "<foo bar=\"ax\"></foo>"
     .attr "bar"
     "ax"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > returns-text-inside-node
+  eq. > @
+    (doc "<foo>bar</foo>").text
+    "bar"

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -44,6 +44,21 @@ import org.junit.jupiter.api.Test;
  */
 final class EOdocTest {
 
+    /**
+     * Attribute object name.
+     */
+    private static final String ATTR_NAME = "attr";
+
+    /**
+     * Element object name.
+     */
+    private static final String ELEM_NAME = "elem";
+
+    /**
+     * Text object name.
+     */
+    private static final String TEXT_NAME = "text";
+
     @Test
     void createsDocument() {
         MatcherAssert.assertThat(
@@ -63,8 +78,11 @@ final class EOdocTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     void findsElementInDocument() {
-        final Phi elem = this.document("<program><test>here</test></program>").take("elem");
+        final Phi elem = this.document("<program><test>here</test></program>").take(
+            EOdocTest.ELEM_NAME
+        );
         elem.put("ename", new Data.ToPhi("program"));
         MatcherAssert.assertThat(
             "Element result doesn't match with expected",
@@ -77,7 +95,9 @@ final class EOdocTest {
 
     @Test
     void findsElementInEmptyRoot() {
-        final Phi elem = this.document("<program/>").take("elem");
+        final Phi elem = this.document("<program/>").take(
+            EOdocTest.ELEM_NAME
+        );
         elem.put("ename", new Data.ToPhi("program"));
         MatcherAssert.assertThat(
             "Element result doesn't match with expected",
@@ -90,7 +110,9 @@ final class EOdocTest {
 
     @Test
     void findsChildElement() {
-        final Phi elem = this.document("<program><test>here</test></program>").take("elem");
+        final Phi elem = this.document("<program><test>here</test></program>").take(
+            EOdocTest.ELEM_NAME
+        );
         elem.put("ename", new Data.ToPhi("test"));
         MatcherAssert.assertThat(
             "Element result doesn't match with expected",
@@ -103,7 +125,9 @@ final class EOdocTest {
 
     @Test
     void returnsAttributeInsideNode() {
-        final Phi attr = this.document("<program test=\"f\"/>").take("attr");
+        final Phi attr = this.document("<program test=\"f\"/>").take(
+            EOdocTest.ATTR_NAME
+        );
         attr.put("aname", new Data.ToPhi("test"));
         MatcherAssert.assertThat(
             "Value does not match with expected",
@@ -126,14 +150,44 @@ final class EOdocTest {
     @Disabled
     @Test
     void returnsAttributeInsideChildNode() {
-        final Phi elem = this.document("<foo><bar x=\"ttt\"></bar></foo>").take("elem");
+        final Phi elem = this.document("<foo><bar x=\"ttt\"></bar></foo>").take(
+            EOdocTest.ELEM_NAME
+        );
         elem.put("ename", new Data.ToPhi("bar"));
-        final Phi attr = elem.take("attr");
+        final Phi attr = elem.take(EOdocTest.ATTR_NAME);
         attr.put("aname", new Data.ToPhi("x"));
         MatcherAssert.assertThat(
             "Value does not match with expected",
             new Dataized(attr).asString(),
             Matchers.equalTo("ttt")
+        );
+    }
+
+    @Test
+    void returnsTextInsideNode() {
+        MatcherAssert.assertThat(
+            "Text does not match with expected",
+            new Dataized(this.document("<foo>here</foo>").take(EOdocTest.TEXT_NAME)).asString(),
+            Matchers.equalTo("here")
+        );
+    }
+
+    /**
+     * Returns text node inside child.
+     * @todo #10:35min Enable this test on text retrieval from child node.
+     *  We should enable this test after cascading in child objects will be implemented.
+     */
+    @Disabled
+    @Test
+    void returnsTextInsideChildNode() {
+        final Phi child = this.document("<abc><c>x</c></abc>").take(
+            EOdocTest.ELEM_NAME
+        );
+        child.put("ename", new Data.ToPhi("c"));
+        MatcherAssert.assertThat(
+            "Text does not match with expected",
+            new Dataized(child.take(EOdocTest.TEXT_NAME)).asString(),
+            Matchers.equalTo("x")
         );
     }
 


### PR DESCRIPTION
In this PR I've implemented new child object inside `doc`: `text`, via `EOdoc$EOxml$EOtext`.

closes #10

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces functionality to handle text nodes within XML documents in the `EOdoc` class and adds corresponding unit tests to ensure proper behavior for text retrieval.

### Detailed summary
- Added `text` handling in `doc.eo`.
- Created a unit test for text retrieval inside XML nodes in `doc-tests.eo`.
- Implemented `EOdoc$EOxml$EOtext` class for processing text nodes.
- Updated tests to use constants for `elem`, `attr`, and `text` names.
- Added a test for retrieving text from child nodes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->