### PR TITLE
feat(#23): XmlParseException in `EOdoc.xml`

### DIFF
--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
@@ -57,7 +57,7 @@ public final class EOdoc$EOxml$EOelem extends PhDefault implements Atom {
     }
 
     @Override
-    public Phi lambda() {
+    public Phi lambda() throws XmlParseException {
         return new Data.ToPhi(
             new XmlNode.Default(new Dataized(this.take(Attr.RHO).take("serialized")).asString())
                 .elem(new Dataized(this.take("ename")).asString())

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOtext.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOtext.java
@@ -43,7 +43,7 @@ import org.eolang.Phi;
 public final class EOdoc$EOxml$EOtext extends PhDefault implements Atom {
 
     @Override
-    public Phi lambda() {
+    public Phi lambda() throws XmlParseException {
         return new Data.ToPhi(
             new XmlNode.Default(new Dataized(this.take(Attr.RHO).take("serialized")).asString())
                 .text().getBytes()

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOφ.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOφ.java
@@ -31,6 +31,7 @@ import org.eolang.Atom;
 import org.eolang.Attr;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -47,14 +48,18 @@ public final class EOdoc$EOφ extends PhDefault implements Atom {
     @Override
     public Phi lambda() {
         final Phi xml = this.take(Attr.RHO).take("xml");
-        xml.put(
-            "serialized",
-            new Data.ToPhi(
-                new XmlNode.Default(
-                    new Dataized(this.take(Attr.RHO).take("data")).asString()
-                ).asString().getBytes()
-            )
-        );
+        try {
+            xml.put(
+                "serialized",
+                new Data.ToPhi(
+                    new XmlNode.Default(
+                        new Dataized(this.take(Attr.RHO).take("data")).asString()
+                    ).asString().getBytes()
+                )
+            );
+        } catch (final XmlParseException exception) {
+            throw new ExFailure("XML document syntax is invalid", exception);
+        }
         return xml;
     }
 }

--- a/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
@@ -27,15 +27,19 @@
  */
 package EOorg.EOeolang.EOdom; // NOPMD
 
+import java.io.IOException;
 import java.io.StringWriter;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.cactoos.io.InputOf;
+import org.cactoos.io.UncheckedInput;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 /**
  * XML Document Node.
@@ -128,7 +132,7 @@ public interface XmlNode {
          * Ctor.
          * @param xml XML as string
          */
-        Default(final String xml) {
+        Default(final String xml) throws XmlParseException {
             this(XmlNode.Default.fromString(xml));
         }
 
@@ -192,17 +196,27 @@ public interface XmlNode {
          * @checkstyle IllegalCatchCheck (10 lines)
          */
         @SuppressWarnings("PMD.AvoidCatchingGenericException")
-        private static Element fromString(final String xml) {
+        private static Element fromString(final String xml) throws XmlParseException {
             try {
                 return DocumentBuilderFactory.newInstance()
                     .newDocumentBuilder()
-                    .parse(new InputOf(xml).stream())
+                    .parse(new UncheckedInput(new InputOf(xml)).stream())
                     .getDocumentElement();
-            } catch (final Exception exception) {
+            } catch (final ParserConfigurationException exception) {
                 throw new IllegalStateException(
+                    String.format(
+                        "Cannot instantiate parser for XML: '%s'",
+                        xml
+                    ),
+                    exception
+                );
+            } catch (final SAXException exception) {
+                throw new XmlParseException(
                     String.format("Cannot parse XML string: '%s'", xml),
                     exception
                 );
+            } catch (final IOException exception) {
+                throw new IllegalStateException("I/O failed", exception);
             }
         }
     }

--- a/src/main/java/EOorg/EOeolang/EOdom/XmlParseException.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/XmlParseException.java
@@ -27,37 +27,18 @@
  */
 package EOorg.EOeolang.EOdom; // NOPMD
 
-import org.eolang.AtVoid;
-import org.eolang.Atom;
-import org.eolang.Attr;
-import org.eolang.Data;
-import org.eolang.Dataized;
-import org.eolang.PhDefault;
-import org.eolang.Phi;
-
 /**
- * Attribute in XML node.
- *
+ * XML parse exception.
  * @since 0.0.0
- * @checkstyle TypeNameCheck (5 lines)
  */
-@SuppressWarnings("PMD.AvoidDollarSigns")
-public final class EOdoc$EOxml$EOattr extends PhDefault implements Atom {
+final class XmlParseException extends Exception {
 
     /**
      * Ctor.
+     * @param message Message
+     * @param cause Context
      */
-    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
-    public EOdoc$EOxml$EOattr() {
-        this.add("aname", new AtVoid("aname"));
-    }
-
-    @Override
-    public Phi lambda() throws XmlParseException {
-        return new Data.ToPhi(
-            new XmlNode.Default(new Dataized(this.take(Attr.RHO).take("serialized")).asString())
-                .attr(new Dataized(this.take("aname")).asString())
-                .getBytes()
-        );
+    XmlParseException(final String message, final Throwable cause) {
+        super(message, cause);
     }
 }

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -33,9 +33,9 @@ import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Tests for {@link EOdoc}.
@@ -70,10 +70,13 @@ final class EOdocTest {
 
     @Test
     void throwsErrorIfInvalidXmlPassed() {
-        Assertions.assertThrows(
-            EOerror.ExError.class,
-            () -> new Dataized(this.document("broken").take("xml")).asString(),
-            () -> "Error should be thrown, since XML is invalid"
+        MatcherAssert.assertThat(
+            "Error was not thrown, though XML is invalid",
+            () -> new Dataized(this.document("broken").take("serialized")).asString(),
+            new Throws<>(
+                Matchers.containsString("XML document syntax is invalid"),
+                EOerror.ExError.class
+            )
         );
     }
 

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -42,6 +42,7 @@ import org.llorllale.cactoos.matchers.Throws;
  *
  * @since 0.0.0
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class EOdocTest {
 
     /**
@@ -191,6 +192,20 @@ final class EOdocTest {
             "Text does not match with expected",
             new Dataized(child.take(EOdocTest.TEXT_NAME)).asString(),
             Matchers.equalTo("x")
+        );
+    }
+
+    @Test
+    void throwsErrorIfAttributeIsNotFound() {
+        final Phi attr = this.document("<foo/>").take(EOdocTest.ATTR_NAME);
+        attr.put("aname", new Data.ToPhi("x"));
+        MatcherAssert.assertThat(
+            "Text does not match with expected",
+            () -> new Dataized(attr).asString(),
+            new Throws<>(
+                Matchers.containsString("Attribute 'x' was not found in the node"),
+                EOerror.ExError.class
+            )
         );
     }
 

--- a/src/test/java/EOorg/EOeolang/EOdom/XmlNodeTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/XmlNodeTest.java
@@ -41,7 +41,7 @@ import org.llorllale.cactoos.matchers.Throws;
 final class XmlNodeTest {
 
     @Test
-    void parsesDocumentFromString() {
+    void parsesDocumentFromString() throws XmlParseException {
         MatcherAssert.assertThat(
             "Parsed document doesn't match with expected",
             new XmlNode.Default("<program><test foo=\"f\">bar</test></program>")
@@ -53,7 +53,16 @@ final class XmlNodeTest {
     }
 
     @Test
-    void parsesNodeFromNextElement() {
+    void throwsIoExceptionOnBrokenXml() {
+        MatcherAssert.assertThat(
+            "Exception was not thrown, but it should",
+            () -> new XmlNode.Default("broken"),
+            new Throws<>("Cannot parse XML string: 'broken'", XmlParseException.class)
+        );
+    }
+
+    @Test
+    void parsesNodeFromNextElement() throws XmlParseException {
         MatcherAssert.assertThat(
             "Parsed document doesn't match with expected",
             new XmlNode.Default("<program><test foo=\"f\">bar</test></program>")
@@ -86,7 +95,7 @@ final class XmlNodeTest {
     }
 
     @Test
-    void findsAttribute() {
+    void findsAttribute() throws XmlParseException {
         MatcherAssert.assertThat(
             "Attribute value does not match with expected",
             new XmlNode.Default("<program><test foo=\"f\">bar</test></program>")
@@ -105,7 +114,7 @@ final class XmlNodeTest {
     }
 
     @Test
-    void returnsTextInside() {
+    void returnsTextInside() throws XmlParseException {
         MatcherAssert.assertThat(
             "Text node does not match with expected",
             new XmlNode.Default("<program>foo</program>").text(),
@@ -114,7 +123,7 @@ final class XmlNodeTest {
     }
 
     @Test
-    void returnsTextAfterChaining() {
+    void returnsTextAfterChaining() throws XmlParseException {
         MatcherAssert.assertThat(
             "Output does not match with expected",
             new XmlNode.Default("<program><test foo=\"f\">bar</test></program>")
@@ -126,7 +135,7 @@ final class XmlNodeTest {
     }
 
     @Test
-    void returnsEmptyText() {
+    void returnsEmptyText() throws XmlParseException {
         MatcherAssert.assertThat(
             "Text should be empty",
             new XmlNode.Default("<program/>").text(),


### PR DESCRIPTION
In this PR I've introduced error handling for invalid XML passing in `doc` object.

see #23
History:
- **feat(#23): XmlParseException, ExFailure**
- **feat(#23): test**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces error handling for XML parsing by adding the `XmlParseException` class and updating existing methods to throw this exception when encountering invalid XML. It also modifies tests to validate the new error handling.

### Detailed summary
- Added `XmlParseException` class for XML parsing errors.
- Updated `lambda()` methods in `EOxml$EOtext`, `EOxml$EOattr`, and `EOxml$EOelem` to throw `XmlParseException`.
- Modified the `lambda()` method in `EOdoc$EOφ` to catch `XmlParseException` and throw `ExFailure`.
- Updated tests in `EOdocTest` to check for thrown exceptions on invalid XML.
- Enhanced `XmlNode` methods to throw `XmlParseException` on parsing errors.
- Updated test methods in `XmlNodeTest` to handle `XmlParseException`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->