### PR TITLE
feat(#35): cascading depth `elem`, `attr`, `text`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,32 @@ Here is how it works:
 ```eo
 +package org.eolang.dom
 
-[] > creates-document-from-string
-  (doc "<document/>").as-string > @ # <document/>
+[] > returns-child-xml-content
+  eq. > @
+    doc
+      "<a><b>x</b></a>"
+    .elem "a"
+    .elem "b"
+    .as-string
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><b>x</b>"
 
-[] > creates-document-from-file
-  (doc "data.xml").as-string > @ # <root><data>test</data></root>
+[] > finds-attribute-in-child-node-in-depth
+  eq. > @
+    doc
+      "<a><b f=\"ttt\">x</b></a>"
+    .elem "a"
+    .elem "b"
+    .attr "f"
+    "ttt"
 
-[] > locates-element
-  (doc "data.xml").xpath "//data/text()" # test
-
-[] > appends-element
-  ((doc "data.xml").xpath "/root").append "kid" # <root><kid/><data>test</data></root> 
+[] > finds-text-in-child-node-in-depth
+  eq. > @
+    doc
+      "<a><b>x</b></a>"
+    .elem "a"
+    .elem "b"
+    .text
+    "x"
 ```
 
 ## How to contribute?

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
@@ -58,13 +58,17 @@ public final class EOdoc$EOxml$EOelem extends PhDefault implements Atom {
 
     @Override
     public Phi lambda() throws XmlParseException {
-        final String result = new XmlNode.Default(
-            new Dataized(this.take(Attr.RHO).take("serialized")).asString()
-            )
-            .elem(new Dataized(this.take("ename")).asString())
-            .asString();
         final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
-        doc.put("data", new Data.ToPhi(result));
+        doc.put(
+            "data",
+            new Data.ToPhi(
+                new XmlNode.Default(
+                    new Dataized(this.take(Attr.RHO).take("serialized")).asString()
+                )
+                    .elem(new Dataized(this.take("ename")).asString())
+                    .asString()
+            )
+        );
         final Phi xml = doc.take("xml");
         xml.put(
             "serialized",

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
@@ -58,10 +58,18 @@ public final class EOdoc$EOxml$EOelem extends PhDefault implements Atom {
 
     @Override
     public Phi lambda() throws XmlParseException {
-        return new Data.ToPhi(
-            new XmlNode.Default(new Dataized(this.take(Attr.RHO).take("serialized")).asString())
-                .elem(new Dataized(this.take("ename")).asString())
-                .asString().getBytes()
+        final String result = new XmlNode.Default(
+                new Dataized(this.take(Attr.RHO).take("serialized")).asString()
+            )
+            .elem(new Dataized(this.take("ename")).asString())
+            .asString();
+        final Phi doc = new EOdoc();
+        doc.put("data", new Data.ToPhi(result));
+        final Phi xml = doc.take("xml");
+        xml.put(
+            "serialized",
+            new Data.ToPhi(new Dataized(xml.take(Attr.RHO).take("data")).asString().getBytes())
         );
+        return doc;
     }
 }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOelem.java
@@ -59,11 +59,11 @@ public final class EOdoc$EOxml$EOelem extends PhDefault implements Atom {
     @Override
     public Phi lambda() throws XmlParseException {
         final String result = new XmlNode.Default(
-                new Dataized(this.take(Attr.RHO).take("serialized")).asString()
+            new Dataized(this.take(Attr.RHO).take("serialized")).asString()
             )
             .elem(new Dataized(this.take("ename")).asString())
             .asString();
-        final Phi doc = new EOdoc();
+        final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
         doc.put("data", new Data.ToPhi(result));
         final Phi xml = doc.take("xml");
         xml.put(

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -40,6 +40,7 @@
     doc
       "<program/>"
     .elem "program"
+    .as-string
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?><program/>"
 
 # This unit test is supposed to check the functionality of the corresponding object.
@@ -48,7 +49,38 @@
     doc
       "<program><test>here</test></program>"
     .elem "test"
+    .as-string
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>here</test>"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > finds-child-elements-recursively
+  eq. > @
+    doc
+      "<a><b>x</b></a>"
+    .elem "a"
+    .elem "b"
+    .as-string
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><b>x</b>"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > finds-attribute-in-child-node-in-depth
+  eq. > @
+    doc
+      "<a><b f=\"ttt\">x</b></a>"
+    .elem "a"
+    .elem "b"
+    .attr "f"
+    "ttt"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > finds-text-in-child-node-in-depth
+  eq. > @
+    doc
+      "<a><b>x</b></a>"
+    .elem "a"
+    .elem "b"
+    .text
+    "x"
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > finds-attribute-inside-node

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -33,7 +33,6 @@ import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Throws;
 
@@ -128,6 +127,21 @@ final class EOdocTest {
     }
 
     @Test
+    void findsChildElementCascading() {
+        final Phi elem = this.document("<a><b><c>here</c></b></a>").take(
+            EOdocTest.ELEM_NAME
+        );
+        elem.put("ename", new Data.ToPhi("a"));
+        final Phi child = elem.take(EOdocTest.ELEM_NAME);
+        child.put("ename", new Data.ToPhi("b"));
+        MatcherAssert.assertThat(
+            "Output does not match with expected",
+            new Dataized(child.take("as-string")).asString(),
+            Matchers.equalTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?><b><c>here</c></b>")
+        );
+    }
+
+    @Test
     void returnsAttributeInsideNode() {
         final Phi attr = this.document("<program test=\"f\"/>").take(
             EOdocTest.ATTR_NAME
@@ -164,12 +178,6 @@ final class EOdocTest {
         );
     }
 
-    /**
-     * Returns text node inside child.
-     * @todo #10:35min Enable this test on text retrieval from child node.
-     *  We should enable this test after cascading in child objects will be implemented.
-     */
-    @Disabled
     @Test
     void returnsTextInsideChildNode() {
         final Phi child = this.document("<abc><c>x</c></abc>").take(

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -90,7 +90,7 @@ final class EOdocTest {
         elem.put("ename", new Data.ToPhi("program"));
         MatcherAssert.assertThat(
             "Element result doesn't match with expected",
-            new Dataized(elem).asString(),
+            new Dataized(elem.take("as-string")).asString(),
             Matchers.equalTo(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><program><test>here</test></program>"
             )
@@ -105,7 +105,7 @@ final class EOdocTest {
         elem.put("ename", new Data.ToPhi("program"));
         MatcherAssert.assertThat(
             "Element result doesn't match with expected",
-            new Dataized(elem).asString(),
+            new Dataized(elem.take("as-string")).asString(),
             Matchers.equalTo(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><program/>"
             )
@@ -120,7 +120,7 @@ final class EOdocTest {
         elem.put("ename", new Data.ToPhi("test"));
         MatcherAssert.assertThat(
             "Element result doesn't match with expected",
-            new Dataized(elem).asString(),
+            new Dataized(elem.take("as-string")).asString(),
             Matchers.equalTo(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>here</test>"
             )
@@ -140,18 +140,6 @@ final class EOdocTest {
         );
     }
 
-    /**
-     * Returns attribute inside child node.
-     * @todo #9:45min Enable this test on attribute fetching after child object
-     *  cascading will be implemented. Currenlty, we can't take `attr` object from
-     *  `elem` object. It should be possible to do this in EO:
-     *  <pre>
-     *  {@code
-     *  ((doc "...").elem "f").attr "x"
-     *  }
-     *  </pre>
-     */
-    @Disabled
     @Test
     void returnsAttributeInsideChildNode() {
         final Phi elem = this.document("<foo><bar x=\"ttt\"></bar></foo>").take(


### PR DESCRIPTION
In this PR I've implemented cascading of `doc` child `elem` object to enable access of `doc`s content via dot notation:

```eo
doc
  "<a><b f=\"ttt\">x</b></a>"
.elem "a"
.elem "b"
.attr "f"
"ttt"
```

closes #35
History:
- **feat(#35): cascading doc**
- **feat(#35): cascading depth tests**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances XML document handling in the `EOxml` module by refining the `lambda` method for better serialization and adding new test cases for various XML operations.

### Detailed summary
- Updated `lambda` method in `EOxml$EOelem` to improve XML document serialization.
- Added new tests for finding child elements, attributes, and text in XML.
- Modified existing tests to ensure they use the correct methods for element retrieval. 
- Removed disabled tests related to attribute and text retrieval from child nodes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->