### PR TITLE
feat(#41): `dom-parser` object

### DIFF
--- a/src/main/eo/org/eolang/dom/dom-parser.eo
+++ b/src/main/eo/org/eolang/dom/dom-parser.eo
@@ -1,0 +1,34 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++architect yegor256@gmail.com
++home https://github.com/h1alexbel/eo-dom
++package org.eolang.dom
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
++version 0.0.0
+
+# The DOM Parser object, that provides the ability to parse XML or HTML source
+# code from a string into a DOM Document.
+[] > dom-parser
+  # Parse string into a DOM document.
+  [data] > parse-from-string /org.eolang.dom.doc

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdom_parser$EOparse_from_string.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdom_parser$EOparse_from_string.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom;
+
+import org.eolang.AtVoid;
+import org.eolang.Atom;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * Parse source string into DOM document.
+ * @since 0.0.0
+ */
+@XmirObject(oname = "dom-parser.parse-from-string")
+public final class EOdom_parser$EOparse_from_string extends PhDefault implements Atom {
+
+    /**
+     * Ctor.
+     */
+    public EOdom_parser$EOparse_from_string() {
+        this.add("data", new AtVoid("data"));
+    }
+
+    @Override
+    public Phi lambda() throws XmlParseException {
+        final Phi data = this.take("data");
+        final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
+        doc.put(
+            "data",
+            new Data.ToPhi(
+                new XmlNode.Default(new Dataized(data).asString()).asString().getBytes()
+            )
+        );
+        return doc;
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdom_parser$EOparse_from_string.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdom_parser$EOparse_from_string.java
@@ -25,7 +25,7 @@
  * @checkstyle PackageNameCheck (4 lines)
  * @checkstyle TrailingCommentCheck (3 lines)
  */
-package EOorg.EOeolang.EOdom;
+package EOorg.EOeolang.EOdom; // NOPMD
 
 import org.eolang.AtVoid;
 import org.eolang.Atom;
@@ -39,13 +39,16 @@ import org.eolang.XmirObject;
 /**
  * Parse source string into DOM document.
  * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
  */
+@SuppressWarnings("PMD.AvoidDollarSigns")
 @XmirObject(oname = "dom-parser.parse-from-string")
 public final class EOdom_parser$EOparse_from_string extends PhDefault implements Atom {
 
     /**
      * Ctor.
      */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public EOdom_parser$EOparse_from_string() {
         this.add("data", new AtVoid("data"));
     }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdom_parser$EOparse_from_string.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdom_parser$EOparse_from_string.java
@@ -31,6 +31,7 @@ import org.eolang.AtVoid;
 import org.eolang.Atom;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -50,15 +51,24 @@ public final class EOdom_parser$EOparse_from_string extends PhDefault implements
     }
 
     @Override
-    public Phi lambda() throws XmlParseException {
+    public Phi lambda() {
         final Phi data = this.take("data");
         final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
-        doc.put(
-            "data",
-            new Data.ToPhi(
-                new XmlNode.Default(new Dataized(data).asString()).asString().getBytes()
-            )
-        );
+        try {
+            doc.put(
+                "data",
+                new Data.ToPhi(
+                    new XmlNode.Default(new Dataized(data).asString()).asString().getBytes()
+                )
+            );
+        } catch (final XmlParseException exception) {
+            throw new ExFailure(
+                String.format(
+                    "XML document syntax is invalid: '%s'", new Dataized(data).asString()
+                ),
+                exception
+            );
+        }
         return doc;
     }
 }

--- a/src/test/eo/org/eolang/dom/dom-parser-tests.eo
+++ b/src/test/eo/org/eolang/dom/dom-parser-tests.eo
@@ -1,0 +1,37 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.dom.dom-parser
++architect yegor256@gmail.com
++home https://github.com/h1alexbel/eo-dom
++tests
++package org.eolang.dom
++version 0.0.0
++unlint broken-ref
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > parses-string-into-document
+  dom-parser.parse-from-string > doc
+    "<books><book title=\"Object Thinking\"/></books>"
+  eq. > @
+    doc.as-string
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><books><book title=\"Object Thinking\"/></books>"

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdom_parserTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdom_parserTest.java
@@ -27,24 +27,25 @@
  */
 package EOorg.EOeolang.EOdom;
 
+import EOorg.EOeolang.EOerror;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Tests for {@link EOdom_parser}.
+ *
  * @since 0.0.0
  */
 final class EOdom_parserTest {
 
     @Test
     void parsersStringIntoDocument() {
-        final Phi parse = Phi.Φ.take("org.eolang.dom.dom-parser").copy()
-            .take("parse-from-string");
-        parse.put("data", new Data.ToPhi("<books><book title=\"Object Thinking\"/></books>"));
+        final Phi parse = this.parser("<books><book title=\"Object Thinking\"/></books>");
         final Phi doc = parse.take("as-string");
         MatcherAssert.assertThat(
             "Parsed document doesn't match with expected",
@@ -53,5 +54,25 @@ final class EOdom_parserTest {
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><books><book title=\"Object Thinking\"/></books>"
             )
         );
+    }
+
+    @Test
+    void throwsOnInvalidXml() {
+        final Phi parser = this.parser("<broken xml here>");
+        MatcherAssert.assertThat(
+            "Parsed document doesn't match with expected",
+            () -> new Dataized(parser.take("doc").take("as-string")).asString(),
+            new Throws<>(
+                Matchers.containsString("XML document syntax is invalid: '<broken xml here>'"),
+                EOerror.ExError.class
+            )
+        );
+    }
+
+    private Phi parser(final String data) {
+        final Phi parse = Phi.Φ.take("org.eolang.dom.dom-parser").copy()
+            .take("parse-from-string");
+        parse.put("data", new Data.ToPhi(data));
+        return parse;
     }
 }

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdom_parserTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdom_parserTest.java
@@ -25,7 +25,7 @@
  * @checkstyle PackageNameCheck (4 lines)
  * @checkstyle TrailingCommentCheck (3 lines)
  */
-package EOorg.EOeolang.EOdom;
+package EOorg.EOeolang.EOdom; // NOPMD
 
 import EOorg.EOeolang.EOerror;
 import org.eolang.Data;
@@ -40,6 +40,7 @@ import org.llorllale.cactoos.matchers.Throws;
  * Tests for {@link EOdom_parser}.
  *
  * @since 0.0.0
+ * @checkstyle TypeNameCheck (3 lines)
  */
 final class EOdom_parserTest {
 

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdom_parserTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdom_parserTest.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom;
+
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link EOdom_parser}.
+ * @since 0.0.0
+ */
+final class EOdom_parserTest {
+
+    @Test
+    void parsersStringIntoDocument() {
+        final Phi parse = Phi.Φ.take("org.eolang.dom.dom-parser").copy()
+            .take("parse-from-string");
+        parse.put("data", new Data.ToPhi("<books><book title=\"Object Thinking\"/></books>"));
+        final Phi doc = parse.take("as-string");
+        MatcherAssert.assertThat(
+            "Parsed document doesn't match with expected",
+            new Dataized(doc).asString(),
+            Matchers.equalTo(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><books><book title=\"Object Thinking\"/></books>"
+            )
+        );
+    }
+}


### PR DESCRIPTION
In this PR I've added `dom-parser` object as mirror from [DOM API](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser).

see #41
History:
- **feat(#41): dom-parser**
- **feat(#41): throws test**
- **feat(#41): EO test**
- **feat(#41): clean for qulice**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a `dom-parser` object for parsing XML or HTML strings into DOM documents, along with corresponding unit tests to validate its functionality.

### Detailed summary
- Introduced `dom-parser` in `src/main/eo/org/eolang/dom/dom-parser.eo`.
- Added `parse-from-string` function to parse strings into DOM documents.
- Created unit tests in `src/test/eo/org/eolang/dom/dom-parser-tests.eo` for parsing functionality.
- Included licensing information in multiple files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->