### PR TITLE
feat(#41): doc.get-elements-by-tag-name

### DIFF
--- a/src/main/eo/org/eolang/dom/element.eo
+++ b/src/main/eo/org/eolang/dom/element.eo
@@ -27,16 +27,7 @@
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
 
-# The doc object allows you to create XML tree-based documents. Serves as
-# an entry-point into the XML-based document's content.
-[data] > doc
-  # XML.
-  [] > @ /org.eolang.dom.doc.xml
-
-  # Serialized data.
-  [serialized] > xml
-    [name] > get-elements-by-tag-name /org.eolang.dom.doc.xml
-    [] > as-string /org.eolang.string
-    [ename] > elem /org.eolang.dom.doc.xml
-    [aname] > attr /org.eolang.dom.doc.xml
-    [] > text /org.eolang.string
+# Object that represent element in a DOM Document.
+[xml] > element
+  # Node as-string.
+  [] > as-string /org.eolang.dom.element

--- a/src/main/eo/org/eolang/dom/html-collection.eo
+++ b/src/main/eo/org/eolang/dom/html-collection.eo
@@ -27,16 +27,8 @@
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
 
-# The doc object allows you to create XML tree-based documents. Serves as
-# an entry-point into the XML-based document's content.
-[data] > doc
-  # XML.
-  [] > @ /org.eolang.dom.doc.xml
-
-  # Serialized data.
-  [serialized] > xml
-    [name] > get-elements-by-tag-name /org.eolang.dom.doc.xml
-    [] > as-string /org.eolang.string
-    [ename] > elem /org.eolang.dom.doc.xml
-    [aname] > attr /org.eolang.dom.doc.xml
-    [] > text /org.eolang.string
+# HTML collection that represents a generic collection of elements (in document order)
+# and offers methods and properties for selecting from the list.
+[nodes] > html-collection
+  # At.
+  [pos] > at /org.eolang.dom.html-collection

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOget_elements_by_tag_name.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOget_elements_by_tag_name.java
@@ -25,7 +25,7 @@
  * @checkstyle PackageNameCheck (4 lines)
  * @checkstyle TrailingCommentCheck (3 lines)
  */
-package EOorg.EOeolang.EOdom;
+package EOorg.EOeolang.EOdom; // NOPMD
 
 import java.io.StringWriter;
 import javax.xml.transform.Transformer;
@@ -45,8 +45,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 /**
- * Get elements by tag name.
- *
+ * Get DOM elements by tag name.
  * @since 0.0.0
  * @checkstyle TypeNameCheck (5 lines)
  */
@@ -57,6 +56,7 @@ public final class EOdoc$EOxml$EOget_elements_by_tag_name extends PhDefault impl
     /**
      * Ctor.
      */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public EOdoc$EOxml$EOget_elements_by_tag_name() {
         this.add("name", new AtVoid("name"));
     }
@@ -67,7 +67,7 @@ public final class EOdoc$EOxml$EOget_elements_by_tag_name extends PhDefault impl
             new Dataized(this.take(Attr.RHO).take("serialized")).asString()
         ).getElementsByTagName(new Dataized(this.take("name")).asString());
         final StringBuilder serialized = new StringBuilder();
-        for (int pos = 0; pos < nodes.getLength(); pos++) {
+        for (int pos = 0; pos < nodes.getLength(); pos += 1) {
             final Node node = nodes.item(pos);
             final StringWriter writer = new StringWriter();
             final Transformer transformer = TransformerFactory.newInstance().newTransformer();

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOget_elements_by_tag_name.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOget_elements_by_tag_name.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom;
+
+import java.io.StringWriter;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.eolang.AtVoid;
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Get elements by tag name.
+ *
+ * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
+ */
+@SuppressWarnings("PMD.AvoidDollarSigns")
+@XmirObject(oname = "doc.xml.get-elements-by-tag-name")
+public final class EOdoc$EOxml$EOget_elements_by_tag_name extends PhDefault implements Atom {
+
+    /**
+     * Ctor.
+     */
+    public EOdoc$EOxml$EOget_elements_by_tag_name() {
+        this.add("name", new AtVoid("name"));
+    }
+
+    @Override
+    public Phi lambda() throws XmlParseException, TransformerException {
+        final NodeList nodes = new XmlNode.Default(
+            new Dataized(this.take(Attr.RHO).take("serialized")).asString()
+        ).getElementsByTagName(new Dataized(this.take("name")).asString());
+        final StringBuilder serialized = new StringBuilder();
+        for (int pos = 0; pos < nodes.getLength(); pos++) {
+            final Node node = nodes.item(pos);
+            final StringWriter writer = new StringWriter();
+            final Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.transform(new DOMSource(node), new StreamResult(writer));
+            serialized.append(writer).append('\n');
+        }
+        final Phi collection = Phi.Φ.take("org.eolang.dom.html-collection");
+        collection.put("nodes", new Data.ToPhi(serialized.toString().getBytes()));
+        return collection;
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOas_string.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOas_string.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom;
+
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * DOM element as string.
+ * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
+ */
+@SuppressWarnings("PMD.AvoidDollarSigns")
+@XmirObject(oname = "element.as-string")
+public final class EOelement$EOas_string extends PhDefault implements Atom {
+
+    @Override
+    public Phi lambda() {
+        return new Data.ToPhi(new Dataized(this.take(Attr.RHO).take("xml")).asString());
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOas_string.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOas_string.java
@@ -25,7 +25,7 @@
  * @checkstyle PackageNameCheck (4 lines)
  * @checkstyle TrailingCommentCheck (3 lines)
  */
-package EOorg.EOeolang.EOdom;
+package EOorg.EOeolang.EOdom; // NOPMD
 
 import org.eolang.Atom;
 import org.eolang.Attr;

--- a/src/main/java/EOorg/EOeolang/EOdom/EOhtml_collection$EOat.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOhtml_collection$EOat.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom;
+
+import java.util.List;
+import org.cactoos.list.ListOf;
+import org.eolang.AtVoid;
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * DOM element at index from node collection.
+ * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
+ */
+@SuppressWarnings("PMD.AvoidDollarSigns")
+@XmirObject(oname = "html-collection.at")
+public final class EOhtml_collection$EOat extends PhDefault implements Atom {
+
+    /**
+     * Ctor.
+     */
+    public EOhtml_collection$EOat() {
+        this.add("pos", new AtVoid("pos"));
+    }
+
+    @Override
+    public Phi lambda() {
+        final Double pos = new Dataized(this.take("pos")).asNumber();
+        final List<String> nodes = new ListOf<>(
+            new Dataized(this.take(Attr.RHO).take("nodes"))
+                .asString().split("\n")
+        );
+        final Phi element = Phi.Φ.take("org.eolang.dom.element");
+        element.put("xml", new Data.ToPhi(nodes.get(pos.intValue())));
+        return element;
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/EOhtml_collection$EOat.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOhtml_collection$EOat.java
@@ -25,7 +25,7 @@
  * @checkstyle PackageNameCheck (4 lines)
  * @checkstyle TrailingCommentCheck (3 lines)
  */
-package EOorg.EOeolang.EOdom;
+package EOorg.EOeolang.EOdom; // NOPMD
 
 import java.util.List;
 import org.cactoos.list.ListOf;
@@ -50,6 +50,7 @@ public final class EOhtml_collection$EOat extends PhDefault implements Atom {
     /**
      * Ctor.
      */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public EOhtml_collection$EOat() {
         this.add("pos", new AtVoid("pos"));
     }

--- a/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
@@ -144,6 +144,10 @@ public interface XmlNode {
             this.base = element;
         }
 
+        public NodeList getElementsByTagName(final String name) {
+            return this.base.getElementsByTagName(name);
+        }
+
         @Override
         public XmlNode elem(final String name) {
             final XmlNode result;

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 +alias org.eolang.dom.doc
++alias org.eolang.dom.dom-parser
 +architect yegor256@gmail.com
 +home https://github.com/h1alexbel/eo-dom
 +tests
@@ -33,6 +34,16 @@
   eq. > @
     (doc "<program/>").as-string
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?><program/>"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > finds-element-at-index
+  dom-parser.parse-from-string > doc
+    "<books><book title=\"Object Thinking\"/><book title=\"Elegant Objects Vol 1.\"/></books>"
+  doc.get-elements-by-tag-name "book" > books
+  books.at 0 > first
+  eq. > @
+    first.as-string
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><book title=\"Object Thinking\"/>"
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > finds-element-in-document

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -205,6 +205,31 @@ final class EOdocTest {
         );
     }
 
+    @Test
+    void retrievesElementsByTagName() {
+        final Phi doc = this.parsedDocument(
+            "<books><book title=\"Object Thinking\"/><book title=\"Elegant Objects Vol 1.\"/></books>"
+        );
+        final Phi retrieval = doc.take("get-elements-by-tag-name");
+        retrieval.put("name", new Data.ToPhi("book"));
+        final Phi at = retrieval.take("at");
+        at.put("pos", new Data.ToPhi(0));
+        MatcherAssert.assertThat(
+            "Retrieved element does not match with expected",
+            new Dataized(at.take("as-string")).asString(),
+            Matchers.equalTo(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><book title=\"Object Thinking\"/>"
+            )
+        );
+    }
+
+    private Phi parsedDocument(final String data) {
+        final Phi parse = Phi.Φ.take("org.eolang.dom.dom-parser").copy()
+            .take("parse-from-string");
+        parse.put("data", new Data.ToPhi(data));
+        return parse;
+    }
+
     private Phi document(final String xml) {
         final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
         doc.put("data", new Data.ToPhi(xml));

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -40,6 +40,9 @@ import org.llorllale.cactoos.matchers.Throws;
  * Tests for {@link EOdoc}.
  *
  * @since 0.0.0
+ * @todo #41:35min Remove all non-compliant doc API from tests.
+ *  We should remove all non-compliant API from `doc` object: as-string, elem,
+ *  attr, text, and so on.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 final class EOdocTest {
@@ -212,11 +215,11 @@ final class EOdocTest {
         );
         final Phi retrieval = doc.take("get-elements-by-tag-name");
         retrieval.put("name", new Data.ToPhi("book"));
-        final Phi at = retrieval.take("at");
-        at.put("pos", new Data.ToPhi(0));
+        final Phi locate = retrieval.take("at");
+        locate.put("pos", new Data.ToPhi(0));
         MatcherAssert.assertThat(
             "Retrieved element does not match with expected",
-            new Dataized(at.take("as-string")).asString(),
+            new Dataized(locate.take("as-string")).asString(),
             Matchers.equalTo(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><book title=\"Object Thinking\"/>"
             )


### PR DESCRIPTION
In this PR I've implemented `doc.get-elements-by-tag-name` as mirror of [Document: getElementsByTagName()](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByTagName) from DOM API.

see #41
History:
- **feat(#41): doc.get-elements-by-tag-name**
- **feat(#41): clean for qulice**
