### PR TITLE
feat(#41): `element.get-attribute`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,32 +25,15 @@ Here is how it works:
 ```eo
 +package org.eolang.dom
 
-[] > returns-child-xml-content
+[] > finds-element-at-index
+  dom-parser.parse-from-string > doc
+    "<books><book title=\"Object Thinking\"/><book title=\"Elegant Objects Vol 1.\"/></books>"
+  doc.get-elements-by-tag-name "book" > books
+  books.at 0 > first
+  first.get-attribute "title" > title
   eq. > @
-    doc
-      "<a><b>x</b></a>"
-    .elem "a"
-    .elem "b"
-    .as-string
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><b>x</b>"
-
-[] > finds-attribute-in-child-node-in-depth
-  eq. > @
-    doc
-      "<a><b f=\"ttt\">x</b></a>"
-    .elem "a"
-    .elem "b"
-    .attr "f"
-    "ttt"
-
-[] > finds-text-in-child-node-in-depth
-  eq. > @
-    doc
-      "<a><b>x</b></a>"
-    .elem "a"
-    .elem "b"
-    .text
-    "x"
+    title
+    "Object Thinking"
 ```
 
 ## How to contribute?

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOget_attribute.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOget_attribute.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom; // NOPMD
+
+import org.eolang.AtVoid;
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * Attribute retrieval from DOM element.
+ *
+ * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
+ */
+@SuppressWarnings("PMD.AvoidDollarSigns")
+@XmirObject(oname = "element.get-attribute")
+public final class EOelement$EOget_attribute extends PhDefault implements Atom {
+
+    /**
+     * Ctor.
+     */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+    public EOelement$EOget_attribute() {
+        this.add("attr", new AtVoid("attr"));
+    }
+
+    @Override
+    public Phi lambda() throws XmlParseException {
+        return new Data.ToPhi(
+            new XmlNode.Default(new Dataized(this.take(Attr.RHO).take("xml")).asString())
+                .attr(new Dataized(this.take("attr")).asString())
+                .getBytes()
+        );
+    }
+}

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -46,6 +46,17 @@
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?><book title=\"Object Thinking\"/>"
 
 # This unit test is supposed to check the functionality of the corresponding object.
+[] > retrieves-attribute-from-first-element
+  dom-parser.parse-from-string > doc
+    "<books><book title=\"Object Thinking\"/><book title=\"Elegant Objects Vol 1.\"/></books>"
+  doc.get-elements-by-tag-name "book" > books
+  books.at 0 > first
+  first.get-attribute "title" > title
+  eq. > @
+    title
+    "Object Thinking"
+
+# This unit test is supposed to check the functionality of the corresponding object.
 [] > finds-element-in-document
   eq. > @
     doc

--- a/src/test/eo/org/eolang/dom/element-tests.eo
+++ b/src/test/eo/org/eolang/dom/element-tests.eo
@@ -20,16 +20,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.dom.element
 +architect yegor256@gmail.com
 +home https://github.com/h1alexbel/eo-dom
++tests
 +package org.eolang.dom
-+rt jvm org.eolang:eo-runtime:0.0.0
-+rt node eo2js-runtime:0.0.0
 +version 0.0.0
++unlint broken-ref
 
-# Object that represent element in a DOM Document.
-[xml] > element
-  # Attribute.
-  [attr] > get-attribute /org.eolang.dom.element
-  # Node as-string.
-  [] > as-string /org.eolang.dom.element
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > retrieves-attribute-from-element
+  eq. > @
+    element
+      "<foo f=\"ttt\"/>"
+    .get-attribute "f"
+    "ttt"

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom; // NOPMD
+
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link EOelement}.
+ *
+ * @since 0.0.0
+ */
+final class EOelementTest {
+
+    @Test
+    void printsElement() {
+        final String xml = "<abc><c>x</c></abc>";
+        MatcherAssert.assertThat(
+            "Element does not match with expected",
+            new Dataized(this.parsed(xml).take("as-string")).asString(),
+            Matchers.equalTo(xml)
+        );
+    }
+
+    @Test
+    void retrievesAttribute() {
+        final Phi attribute = this.parsed("<foo bar=\"f\"/>").take("get-attribute");
+        attribute.put("attr", new Data.ToPhi("bar"));
+        MatcherAssert.assertThat(
+            "Attribute value does not match with expected",
+            new Dataized(attribute).asString(),
+            Matchers.equalTo("f")
+        );
+    }
+
+    @Test
+    void retrievesAttributeInCompositeElement() {
+        final Phi attribute = this.parsed(
+            "<a x=\"top\"><b x=\"in\"></b></a>"
+        ).take("get-attribute");
+        attribute.put("attr", new Data.ToPhi("x"));
+        MatcherAssert.assertThat(
+            "Attribute value does not match with expected",
+            new Dataized(attribute).asString(),
+            Matchers.equalTo("top")
+        );
+    }
+
+    private Phi parsed(final String xml) {
+        final Phi element = Phi.Φ.take("org.eolang.dom.element").copy();
+        element.put("xml", new Data.ToPhi(xml));
+        return element;
+    }
+}


### PR DESCRIPTION
In this PR I've implemented `element.get-attribute` object, as mirror of [Element: getAttribute()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttribute) from DOM API.

see #41

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an `element` object for DOM manipulation, adds attribute retrieval functionality, and includes corresponding unit tests to ensure the reliability of the new features.

### Detailed summary
- Added `get-attribute` method to `element` in `src/main/eo/org/eolang/dom/element.eo`.
- Created unit tests for attribute retrieval in `src/test/eo/org/eolang/dom/element-tests.eo`.
- Updated existing tests in `src/test/eo/org/eolang/dom/doc-tests.eo` for new functionality.
- Removed outdated test cases from `README.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->