### PR TITLE
bug(#49): node runtime off

### DIFF
--- a/src/main/eo/org/eolang/dom/doc.eo
+++ b/src/main/eo/org/eolang/dom/doc.eo
@@ -24,7 +24,6 @@
 +home https://github.com/h1alexbel/eo-dom
 +package org.eolang.dom
 +rt jvm org.eolang:eo-runtime:0.0.0
-+rt node eo2js-runtime:0.0.0
 +version 0.0.0
 
 # The doc object allows you to create XML tree-based documents. Serves as

--- a/src/main/eo/org/eolang/dom/dom-parser.eo
+++ b/src/main/eo/org/eolang/dom/dom-parser.eo
@@ -24,7 +24,6 @@
 +home https://github.com/h1alexbel/eo-dom
 +package org.eolang.dom
 +rt jvm org.eolang:eo-runtime:0.0.0
-+rt node eo2js-runtime:0.0.0
 +version 0.0.0
 
 # The DOM Parser object, that provides the ability to parse XML or HTML source

--- a/src/main/eo/org/eolang/dom/element.eo
+++ b/src/main/eo/org/eolang/dom/element.eo
@@ -24,7 +24,6 @@
 +home https://github.com/h1alexbel/eo-dom
 +package org.eolang.dom
 +rt jvm org.eolang:eo-runtime:0.0.0
-+rt node eo2js-runtime:0.0.0
 +version 0.0.0
 
 # Object that represent element inside DOM Document.

--- a/src/main/eo/org/eolang/dom/html-collection.eo
+++ b/src/main/eo/org/eolang/dom/html-collection.eo
@@ -24,7 +24,6 @@
 +home https://github.com/h1alexbel/eo-dom
 +package org.eolang.dom
 +rt jvm org.eolang:eo-runtime:0.0.0
-+rt node eo2js-runtime:0.0.0
 +version 0.0.0
 
 # HTML collection that represents a generic collection of elements (in document order)


### PR DESCRIPTION
In this PR I've removed `+rt node` from all `src/main/eolang/*.eo` files, since JavaScript runtime does not implement `eo-dom` objects.

closes #49

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `org.eolang.dom` package by changing the runtime dependency from `eo2js-runtime` to `eo-runtime` and sets the version to `0.0.0` across multiple files.

### Detailed summary
- Updated `package` declaration to `org.eolang.dom` in all affected files.
- Changed runtime dependency from `eo2js-runtime:0.0.0` to `eo-runtime:0.0.0`.
- Set version to `0.0.0` in all affected files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->