### PR TITLE
feat(#50): doc.get-element-by-tag-name-ns

### DIFF
--- a/src/main/eo/org/eolang/dom/doc.eo
+++ b/src/main/eo/org/eolang/dom/doc.eo
@@ -35,6 +35,9 @@
   # Serialized data.
   [serialized] > xml
     [name] > get-elements-by-tag-name /org.eolang.dom.doc.xml
+    # Retrieves a list of elements with the given tag name belonging to the given namespace.
+    # The complete document is searched, including the root node.
+    [ns name] > get-elements-by-tag-name-ns /org.eolang.dom.doc.xml
     # Returns an element whose id property matches the specified string.
     # Since element IDs are required to be unique if specified, they're a
     # useful way to get access to a specific element quickly.

--- a/src/main/eo/org/eolang/dom/html-collection.eo
+++ b/src/main/eo/org/eolang/dom/html-collection.eo
@@ -31,3 +31,5 @@
 [nodes] > html-collection
   # At.
   [pos] > at /org.eolang.dom.html-collection
+  # Lenght of the current collection.
+  [] > length /org.eolang.dom.html-collection

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOget_elements_by_tag_name.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOget_elements_by_tag_name.java
@@ -27,15 +27,10 @@
  */
 package EOorg.EOeolang.EOdom; // NOPMD
 
-import java.io.StringWriter;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import org.eolang.AtVoid;
 import org.eolang.Atom;
 import org.eolang.Attr;
-import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -67,15 +62,16 @@ public final class EOdoc$EOxml$EOget_elements_by_tag_name extends PhDefault impl
         final NodeList nodes = new XmlNode.Default(
             new Dataized(this.take(Attr.RHO).take("serialized")).asString()
         ).getElementsByTagName(new Dataized(this.take("name")).asString());
-        final StringBuilder serialized = new StringBuilder();
-        for (int pos = 0; pos < nodes.getLength(); pos += 1) {
-            final StringWriter writer = new StringWriter();
-            TransformerFactory.newInstance().newTransformer()
-                .transform(new DOMSource(nodes.item(pos)), new StreamResult(writer));
-            serialized.append(writer).append('\n');
-        }
-        final Phi collection = Phi.Φ.take("org.eolang.dom.html-collection");
-        collection.put("nodes", new Data.ToPhi(serialized.toString().getBytes()));
-        return collection;
+        return new NodesCollection(nodes).value();
+//        final StringBuilder serialized = new StringBuilder();
+//        for (int pos = 0; pos < nodes.getLength(); pos += 1) {
+//            final StringWriter writer = new StringWriter();
+//            TransformerFactory.newInstance().newTransformer()
+//                .transform(new DOMSource(nodes.item(pos)), new StreamResult(writer));
+//            serialized.append(writer).append('\n');
+//        }
+//        final Phi collection = Phi.Φ.take("org.eolang.dom.html-collection");
+//        collection.put("nodes", new Data.ToPhi(serialized.toString().getBytes()));
+//        return collection;
     }
 }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOget_elements_by_tag_name.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOget_elements_by_tag_name.java
@@ -35,7 +35,6 @@ import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
-import org.w3c.dom.NodeList;
 
 /**
  * Get DOM elements by tag name.
@@ -59,19 +58,10 @@ public final class EOdoc$EOxml$EOget_elements_by_tag_name extends PhDefault impl
 
     @Override
     public Phi lambda() throws XmlParseException, TransformerException {
-        final NodeList nodes = new XmlNode.Default(
-            new Dataized(this.take(Attr.RHO).take("serialized")).asString()
-        ).getElementsByTagName(new Dataized(this.take("name")).asString());
-        return new NodesCollection(nodes).value();
-//        final StringBuilder serialized = new StringBuilder();
-//        for (int pos = 0; pos < nodes.getLength(); pos += 1) {
-//            final StringWriter writer = new StringWriter();
-//            TransformerFactory.newInstance().newTransformer()
-//                .transform(new DOMSource(nodes.item(pos)), new StreamResult(writer));
-//            serialized.append(writer).append('\n');
-//        }
-//        final Phi collection = Phi.Φ.take("org.eolang.dom.html-collection");
-//        collection.put("nodes", new Data.ToPhi(serialized.toString().getBytes()));
-//        return collection;
+        return new NodesCollection(
+            new XmlNode.Default(
+                new Dataized(this.take(Attr.RHO).take("serialized")).asString()
+            ).getElementsByTagName(new Dataized(this.take("name")).asString())
+        ).value();
     }
 }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOget_elements_by_tag_name_ns.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOget_elements_by_tag_name_ns.java
@@ -1,0 +1,36 @@
+package EOorg.EOeolang.EOdom;
+
+import javax.xml.transform.TransformerException;
+import org.eolang.AtVoid;
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+import org.w3c.dom.NodeList;
+
+/**
+ * Elements by tag name in the given namespace.
+ *
+ * @since 0.0.0
+ */
+@XmirObject(oname = "doc.xml.get-elements-by-tag-name-ns")
+public final class EOdoc$EOxml$EOget_elements_by_tag_name_ns extends PhDefault implements Atom {
+
+    public EOdoc$EOxml$EOget_elements_by_tag_name_ns() {
+        this.add("ns", new AtVoid("ns"));
+        this.add("name", new AtVoid("name"));
+    }
+
+    @Override
+    public Phi lambda() throws XmlParseException, TransformerException {
+        final NodeList nodes = new XmlNode.Default(
+            new Dataized(this.take(Attr.RHO).take("serialized")).asString()
+        ).getElementsByTagNameNs(
+            new Dataized(this.take("ns")).asString(),
+            new Dataized(this.take("name")).asString()
+        );
+        return new NodesCollection(nodes).value();
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOget_elements_by_tag_name_ns.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOget_elements_by_tag_name_ns.java
@@ -1,4 +1,31 @@
-package EOorg.EOeolang.EOdom;
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom; // NOPMD
 
 import javax.xml.transform.TransformerException;
 import org.eolang.AtVoid;
@@ -8,16 +35,21 @@ import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
-import org.w3c.dom.NodeList;
 
 /**
  * Elements by tag name in the given namespace.
  *
  * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
  */
+@SuppressWarnings("PMD.AvoidDollarSigns")
 @XmirObject(oname = "doc.xml.get-elements-by-tag-name-ns")
 public final class EOdoc$EOxml$EOget_elements_by_tag_name_ns extends PhDefault implements Atom {
 
+    /**
+     * Ctor.
+     */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public EOdoc$EOxml$EOget_elements_by_tag_name_ns() {
         this.add("ns", new AtVoid("ns"));
         this.add("name", new AtVoid("name"));
@@ -25,12 +57,13 @@ public final class EOdoc$EOxml$EOget_elements_by_tag_name_ns extends PhDefault i
 
     @Override
     public Phi lambda() throws XmlParseException, TransformerException {
-        final NodeList nodes = new XmlNode.Default(
-            new Dataized(this.take(Attr.RHO).take("serialized")).asString()
-        ).getElementsByTagNameNs(
-            new Dataized(this.take("ns")).asString(),
-            new Dataized(this.take("name")).asString()
-        );
-        return new NodesCollection(nodes).value();
+        return new NodesCollection(
+            new XmlNode.Default(
+                new Dataized(this.take(Attr.RHO).take("serialized")).asString()
+            ).getElementsByTagNameNs(
+                new Dataized(this.take("ns")).asString(),
+                new Dataized(this.take("name")).asString()
+            )
+        ).value();
     }
 }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOhtml_collection$EOlength.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOhtml_collection$EOlength.java
@@ -1,3 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
 package EOorg.EOeolang.EOdom; // NOPMD
 
 import org.cactoos.list.ListOf;
@@ -13,7 +40,9 @@ import org.eolang.XmirObject;
  * Length of node collection.
  *
  * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
  */
+@SuppressWarnings("PMD.AvoidDollarSigns")
 @XmirObject(oname = "html-collection.length")
 public final class EOhtml_collection$EOlength extends PhDefault implements Atom {
 

--- a/src/main/java/EOorg/EOeolang/EOdom/EOhtml_collection$EOlength.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOhtml_collection$EOlength.java
@@ -1,0 +1,29 @@
+package EOorg.EOeolang.EOdom; // NOPMD
+
+import org.cactoos.list.ListOf;
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * Length of node collection.
+ *
+ * @since 0.0.0
+ */
+@XmirObject(oname = "html-collection.length")
+public final class EOhtml_collection$EOlength extends PhDefault implements Atom {
+
+    @Override
+    public Phi lambda() throws Exception {
+        return new Data.ToPhi(
+            new ListOf<>(
+                new Dataized(this.take(Attr.RHO).take("nodes"))
+                    .asString().split("\n")
+            ).size()
+        );
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/NodesCollection.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/NodesCollection.java
@@ -1,3 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
 package EOorg.EOeolang.EOdom; // NOPMD
 
 import java.io.StringWriter;

--- a/src/main/java/EOorg/EOeolang/EOdom/NodesCollection.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/NodesCollection.java
@@ -1,0 +1,45 @@
+package EOorg.EOeolang.EOdom; // NOPMD
+
+import java.io.StringWriter;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.cactoos.Scalar;
+import org.eolang.Data;
+import org.eolang.Phi;
+import org.w3c.dom.NodeList;
+
+/**
+ * Collection of nodes.
+ * @since 0.0.0
+ */
+public final class NodesCollection implements Scalar<Phi> {
+
+    /**
+     * Nodes.
+     */
+    private final NodeList nodes;
+
+    /**
+     * Ctor.
+     * @param nds Nodes
+     */
+    public NodesCollection(final NodeList nds) {
+        this.nodes = nds;
+    }
+
+    @Override
+    public Phi value() throws TransformerException {
+        final StringBuilder serialized = new StringBuilder();
+        for (int pos = 0; pos < this.nodes.getLength(); pos += 1) {
+            final StringWriter writer = new StringWriter();
+            TransformerFactory.newInstance().newTransformer()
+                .transform(new DOMSource(this.nodes.item(pos)), new StreamResult(writer));
+            serialized.append(writer).append('\n');
+        }
+        final Phi collection = Phi.Φ.take("org.eolang.dom.html-collection");
+        collection.put("nodes", new Data.ToPhi(serialized.toString().getBytes()));
+        return collection;
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
@@ -147,6 +147,10 @@ public interface XmlNode {
             return this.base.getElementsByTagName(name);
         }
 
+        public NodeList getElementsByTagNameNs(final String namespace, final String local) {
+            return this.base.getOwnerDocument().getElementsByTagNameNS(namespace, local);
+        }
+
         @Override
         public XmlNode elem(final String name) {
             final XmlNode result;
@@ -201,7 +205,9 @@ public interface XmlNode {
         @SuppressWarnings("PMD.AvoidCatchingGenericException")
         private static Element fromString(final String xml) throws XmlParseException {
             try {
-                return DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                dbf.setNamespaceAware(true);
+                return dbf.newDocumentBuilder()
                     .parse(new ByteArrayInputStream(xml.getBytes()))
                     .getDocumentElement();
             } catch (final ParserConfigurationException exception) {

--- a/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
@@ -44,6 +44,10 @@ import org.xml.sax.SAXException;
  * XML Document Node.
  *
  * @since 0.0.0
+ * @todo #50:60min Refactor XmlNode interface and it's implementations.
+ *  Originally it was designed to present the behaviour of node in DOM document.
+ *  Now, we should refactor and decompose this interface to present basic DOM element
+ *  with an entry point to W3C API.
  */
 public interface XmlNode {
 

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -74,3 +74,12 @@
   eq. > @
     elements.length
     2
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > retrieves-elements-in-wildcard-namespace
+  dom-parser.parse-from-string > doc
+    "<root xmlns:x=\"https://foo.com/ns\" xmlns:y=\"https://y.com/ns\"><x:f>first</x:f><x:f>second</x:f><y:f>third</y:f></root>"
+  doc.get-elements-by-tag-name-ns "*" "f" > elements
+  eq. > @
+    elements.length
+    3

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -65,3 +65,12 @@
       "Moscow"
     .get-attribute "id"
     "Moscow"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > retrieves-elements-in-namespace
+  dom-parser.parse-from-string > doc
+    "<root xmlns:x=\"https://foo.com/ns\"><x:foo>first</x:foo><x:foo>second</x:foo><x:bar>it is bar</x:bar></root>"
+  doc.get-elements-by-tag-name-ns "https://foo.com/ns" "foo" > elements
+  eq. > @
+    elements.length
+    2

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -85,6 +85,97 @@ final class EOdocTest {
     }
 
     @Test
+    void retrievesElementsByTagNameInNs() {
+        final Phi doc = this.parsedDocument(
+            String.join(
+                "\n",
+                "<app xmlns:e=\"https://example.com/e\" xmlns:t=\"https://example.com/t\">",
+                "<e:foo>Boom e</e:foo>",
+                "<t:foo>Boom t</t:foo>",
+                "</app>"
+            )
+        );
+        final Phi retrieval = doc.take("get-elements-by-tag-name-ns");
+        retrieval.put("ns", new Data.ToPhi("https://example.com/e"));
+        retrieval.put("name", new Data.ToPhi("foo"));
+        final Phi locate = retrieval.take("at");
+        locate.put("pos", new Data.ToPhi(0));
+        MatcherAssert.assertThat(
+            "Text content does not match with expected",
+            new Dataized(locate.take("text-content")).asString(),
+            Matchers.equalTo("Boom e")
+        );
+    }
+
+    @Test
+    void retrievesElementsWithWildcardNs() {
+        final Phi doc = this.parsedDocument(
+            String.join(
+                "\n",
+                "<main xmlns:foo=\"https://foo.com\" xmlns:bar=\"https://bar.com\">",
+                "<foo:o>foo o</foo:o>",
+                "<bar:o>bar o</bar:o>",
+                "<x>just x</x>",
+                "</main>"
+            )
+        );
+        final Phi retrieval = doc.take("get-elements-by-tag-name-ns");
+        retrieval.put("ns", new Data.ToPhi("*"));
+        retrieval.put("name", new Data.ToPhi("o"));
+        MatcherAssert.assertThat(
+            "Nodes count does not match with expected",
+            new Dataized(retrieval.take("length")).asNumber().intValue(),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
+    void retrievesAllElementsInGivenNamespace() {
+        final Phi doc = this.parsedDocument(
+            String.join(
+                "\n",
+                "<main xmlns:one=\"https://one.com\" xmlns:two=\"https://two.com\">",
+                "<one:foo>x</one:foo>",
+                "<one:bar>y</one:bar>",
+                "<one:xyz>z</one:xyz>",
+                "</main>"
+            )
+        );
+        final Phi retrieval = doc.take("get-elements-by-tag-name-ns");
+        retrieval.put("ns", new Data.ToPhi("https://one.com"));
+        retrieval.put("name", new Data.ToPhi("*"));
+        MatcherAssert.assertThat(
+            "Nodes count does not match with expected",
+            new Dataized(retrieval.take("length")).asNumber().intValue(),
+            Matchers.equalTo(3)
+        );
+    }
+
+    @Test
+    void retrievesWildcardElementsInWildcardNs() {
+        final Phi doc = this.parsedDocument(
+            String.join(
+                "\n",
+                "<main xmlns:one=\"https://one.com\" xmlns:two=\"https://two.com\">",
+                "<one:foo>x</one:foo>",
+                "<one:bar>y</one:bar>",
+                "<one:xyz>z</one:xyz>",
+                "<two:t>z</two:t>",
+                "<two:f>z</two:f>",
+                "</main>"
+            )
+        );
+        final Phi retrieval = doc.take("get-elements-by-tag-name-ns");
+        retrieval.put("ns", new Data.ToPhi("*"));
+        retrieval.put("name", new Data.ToPhi("*"));
+        MatcherAssert.assertThat(
+            "Nodes count does not match with expected",
+            new Dataized(retrieval.take("length")).asNumber().intValue(),
+            Matchers.equalTo(12)
+        );
+    }
+
+    @Test
     void findsElementsWithIdTogetherWithChildElements() {
         final Phi bid = this.parsedDocument(
             String.join(

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -42,7 +42,7 @@ import org.llorllale.cactoos.matchers.Throws;
  *
  * @since 0.0.0
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
 final class EOdocTest {
 
     @Test


### PR DESCRIPTION
In this PR I've introduced new object: `doc.get-element-by-tag-name`, a copy of [Document.getElementsByTagNameNS()](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByTagNameNS) from JavaScript DOM API.

closes #50
History:
- **feat(#50): works**
- **feat(#50): clean for qulice, puzzles**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the DOM manipulation capabilities by introducing methods to retrieve elements by tag name within a specified namespace and adding functionality to measure the length of HTML collections.

### Detailed summary
- Added `length` method in `org.eolang.dom.html-collection`.
- Introduced `get-elements-by-tag-name-ns` method in `org.eolang.dom.doc.xml`.
- Implemented tests for retrieving elements by namespace and wildcard namespace.
- Created `NodesCollection` class for managing collections of nodes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->