### PR TITLE
feat(#51): doc.create-element

### DIFF
--- a/src/main/eo/org/eolang/dom/doc.eo
+++ b/src/main/eo/org/eolang/dom/doc.eo
@@ -28,11 +28,13 @@
 
 # The doc object allows you to create XML tree-based documents. Serves as
 # an entry-point into the XML-based document's content.
-[data] > doc
+[] > doc
   # XML.
-  [] > @ /org.eolang.dom.doc.xml
+  [data] > @ /org.eolang.dom.doc.xml
+  # Creates the DOM element specified by `lname`.
+  [lname] > create-element /org.eolang.dom.doc.xml
 
-  # Serialized data.
+  # Serialized XML.
   [serialized] > xml
     [name] > get-elements-by-tag-name /org.eolang.dom.doc.xml
     # Retrieves a list of elements with the given tag name belonging to the given namespace.

--- a/src/main/eo/org/eolang/dom/doc.eo
+++ b/src/main/eo/org/eolang/dom/doc.eo
@@ -31,8 +31,6 @@
 [] > doc
   # XML.
   [data] > @ /org.eolang.dom.doc.xml
-  # Creates the DOM element specified by `lname`.
-  [lname] > create-element /org.eolang.dom.doc.xml
 
   # Serialized XML.
   [serialized] > xml
@@ -45,3 +43,7 @@
     # useful way to get access to a specific element quickly.
     [identifier] > get-element-by-id /org.eolang.dom.doc.xml
     [] > as-string /org.eolang.string
+    # Creates the DOM element specified by `lname`.
+    [lname] > create-element /org.eolang.dom.doc.xml
+    # Appends child to DOM document.
+    [child] > append-child /org.eolang.dom.doc

--- a/src/main/eo/org/eolang/dom/element.eo
+++ b/src/main/eo/org/eolang/dom/element.eo
@@ -34,5 +34,7 @@
   [] > text-content /org.eolang.dom.element
   # Element with attribute.
   [attr value] > with-attribute /org.eolang.dom.element
+  # Element with text content.
+  [content] > with-text /org.eolang.dom.element
   # Node as-string.
   [] > as-string /org.eolang.dom.element

--- a/src/main/eo/org/eolang/dom/element.eo
+++ b/src/main/eo/org/eolang/dom/element.eo
@@ -32,5 +32,7 @@
   [attr] > get-attribute /org.eolang.dom.element
   # Text content inside element.
   [] > text-content /org.eolang.dom.element
+  # Element with attribute.
+  [attr value] > with-attribute /org.eolang.dom.element
   # Node as-string.
   [] > as-string /org.eolang.dom.element

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOcreate_element.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOcreate_element.java
@@ -1,0 +1,43 @@
+package EOorg.EOeolang.EOdom;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.eolang.AtVoid;
+import org.eolang.Atom;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * Create DOM element.
+ *
+ * @since 0.0.0
+ */
+@XmirObject(oname = "doc.create-element")
+public final class EOdoc$EOcreate_element extends PhDefault implements Atom {
+
+    /**
+     * Ctor.
+     */
+    public EOdoc$EOcreate_element() {
+        this.add("lname", new AtVoid("lname"));
+    }
+
+    @Override
+    public Phi lambda() throws Exception {
+        final Phi elem = Phi.Φ.take("org.eolang.dom.element");
+        elem.put(
+            "xml",
+            new Data.ToPhi(
+                new XmlNode.Default(
+                    DocumentBuilderFactory.newInstance()
+                        .newDocumentBuilder()
+                        .newDocument()
+                        .createElement(new Dataized(this.take("lname")).asString())
+                ).asString()
+            )
+        );
+        return elem;
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOappend_child.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOappend_child.java
@@ -1,5 +1,10 @@
 package EOorg.EOeolang.EOdom;
 
+import java.io.IOException;
+import java.io.StringReader;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import org.eolang.AtVoid;
 import org.eolang.Atom;
 import org.eolang.Attr;
@@ -8,7 +13,10 @@ import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
-import org.w3c.dom.Element;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 /**
  * Append child to the document.
@@ -26,18 +34,26 @@ public final class EOdoc$EOxml$EOappend_child extends PhDefault implements Atom 
     }
 
     @Override
-    public Phi lambda() throws XmlParseException {
-        final String xml = new XmlNode.Default(
-            (Element)
-                new XmlNode.Default(
-                    new Dataized(this.take(Attr.RHO).take("serialized")).asString()
-                ).self().appendChild(
-                    new XmlNode.Default(new Dataized(this.take("child").take("as-string")).asString())
-                        .self()
-                )
-        ).asString();
+    public Phi lambda() throws XmlParseException, ParserConfigurationException, IOException, SAXException {
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        final DocumentBuilder builder = factory.newDocumentBuilder();
+        final Document base = builder.parse(
+            new InputSource(
+                new StringReader(new Dataized(this.take(Attr.RHO).take("serialized")).asString())
+            )
+        );
+        final Document child = builder.parse(
+            new InputSource(
+                new StringReader(new Dataized(this.take("child").take("as-string")).asString())
+            )
+        );
+        final Node imported = base.importNode(child.getDocumentElement(), true);
+        base.getDocumentElement().appendChild(imported);
         final Phi fresh = Phi.Φ.take("org.eolang.dom.doc").copy().take(Attr.PHI);
-        fresh.put("data", new Data.ToPhi(xml));
+        fresh.put(
+            "data",
+            new Data.ToPhi(new XmlNode.Default(base.getDocumentElement()).asString().getBytes())
+        );
         return fresh;
     }
 }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOappend_child.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOappend_child.java
@@ -1,0 +1,43 @@
+package EOorg.EOeolang.EOdom;
+
+import org.eolang.AtVoid;
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+import org.w3c.dom.Element;
+
+/**
+ * Append child to the document.
+ *
+ * @since 0.0.0
+ */
+@XmirObject(oname = "doc.xml.append-child")
+public final class EOdoc$EOxml$EOappend_child extends PhDefault implements Atom {
+
+    /**
+     * Ctor.
+     */
+    public EOdoc$EOxml$EOappend_child() {
+        this.add("child", new AtVoid("child"));
+    }
+
+    @Override
+    public Phi lambda() throws XmlParseException {
+        final String xml = new XmlNode.Default(
+            (Element)
+                new XmlNode.Default(
+                    new Dataized(this.take(Attr.RHO).take("serialized")).asString()
+                ).self().appendChild(
+                    new XmlNode.Default(new Dataized(this.take("child").take("as-string")).asString())
+                        .self()
+                )
+        ).asString();
+        final Phi fresh = Phi.Φ.take("org.eolang.dom.doc").copy().take(Attr.PHI);
+        fresh.put("data", new Data.ToPhi(xml));
+        return fresh;
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOappend_child.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOappend_child.java
@@ -1,4 +1,31 @@
-package EOorg.EOeolang.EOdom;
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom; // NOPMD
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -14,7 +41,6 @@ import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
 import org.w3c.dom.Document;
-import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
@@ -22,19 +48,22 @@ import org.xml.sax.SAXException;
  * Append child to the document.
  *
  * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
  */
+@SuppressWarnings("PMD.AvoidDollarSigns")
 @XmirObject(oname = "doc.xml.append-child")
 public final class EOdoc$EOxml$EOappend_child extends PhDefault implements Atom {
 
     /**
      * Ctor.
      */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public EOdoc$EOxml$EOappend_child() {
         this.add("child", new AtVoid("child"));
     }
 
     @Override
-    public Phi lambda() throws XmlParseException, ParserConfigurationException, IOException, SAXException {
+    public Phi lambda() throws ParserConfigurationException, IOException, SAXException {
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         final DocumentBuilder builder = factory.newDocumentBuilder();
         final Document base = builder.parse(
@@ -42,13 +71,18 @@ public final class EOdoc$EOxml$EOappend_child extends PhDefault implements Atom 
                 new StringReader(new Dataized(this.take(Attr.RHO).take("serialized")).asString())
             )
         );
-        final Document child = builder.parse(
-            new InputSource(
-                new StringReader(new Dataized(this.take("child").take("as-string")).asString())
+        base.getDocumentElement().appendChild(
+            base.importNode(
+                builder.parse(
+                    new InputSource(
+                        new StringReader(
+                            new Dataized(this.take("child").take("as-string")).asString()
+                        )
+                    )
+                ).getDocumentElement(),
+                true
             )
         );
-        final Node imported = base.importNode(child.getDocumentElement(), true);
-        base.getDocumentElement().appendChild(imported);
         final Phi fresh = Phi.Φ.take("org.eolang.dom.doc").copy().take(Attr.PHI);
         fresh.put(
             "data",

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOcreate_element.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOcreate_element.java
@@ -1,4 +1,31 @@
-package EOorg.EOeolang.EOdom;
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom; // NOPMD
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.eolang.AtVoid;
@@ -13,13 +40,16 @@ import org.eolang.XmirObject;
  * Create DOM element.
  *
  * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
  */
+@SuppressWarnings("PMD.AvoidDollarSigns")
 @XmirObject(oname = "doc.xml.create-element")
 public final class EOdoc$EOxml$EOcreate_element extends PhDefault implements Atom {
 
     /**
      * Ctor.
      */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public EOdoc$EOxml$EOcreate_element() {
         this.add("lname", new AtVoid("lname"));
     }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOcreate_element.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOcreate_element.java
@@ -14,13 +14,13 @@ import org.eolang.XmirObject;
  *
  * @since 0.0.0
  */
-@XmirObject(oname = "doc.create-element")
-public final class EOdoc$EOcreate_element extends PhDefault implements Atom {
+@XmirObject(oname = "doc.xml.create-element")
+public final class EOdoc$EOxml$EOcreate_element extends PhDefault implements Atom {
 
     /**
      * Ctor.
      */
-    public EOdoc$EOcreate_element() {
+    public EOdoc$EOxml$EOcreate_element() {
         this.add("lname", new AtVoid("lname"));
     }
 

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOφ.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOφ.java
@@ -27,6 +27,7 @@
  */
 package EOorg.EOeolang.EOdom; // NOPMD
 
+import org.eolang.AtVoid;
 import org.eolang.Atom;
 import org.eolang.Attr;
 import org.eolang.Data;
@@ -45,6 +46,13 @@ import org.eolang.XmirObject;
 @XmirObject(oname = "doc.xml")
 public final class EOdoc$EOφ extends PhDefault implements Atom {
 
+    /**
+     * Ctor.
+     */
+    public EOdoc$EOφ() {
+        this.add("data", new AtVoid("data"));
+    }
+
     @Override
     public Phi lambda() {
         final Phi xml = this.take(Attr.RHO).take("xml");
@@ -53,7 +61,7 @@ public final class EOdoc$EOφ extends PhDefault implements Atom {
                 "serialized",
                 new Data.ToPhi(
                     new XmlNode.Default(
-                        new Dataized(this.take(Attr.RHO).take("data")).asString()
+                        new Dataized(this.take("data")).asString()
                     ).asString().getBytes()
                 )
             );

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOφ.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOφ.java
@@ -49,6 +49,7 @@ public final class EOdoc$EOφ extends PhDefault implements Atom {
     /**
      * Ctor.
      */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public EOdoc$EOφ() {
         this.add("data", new AtVoid("data"));
     }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdom_parser$EOparse_from_string.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdom_parser$EOparse_from_string.java
@@ -29,6 +29,7 @@ package EOorg.EOeolang.EOdom; // NOPMD
 
 import org.eolang.AtVoid;
 import org.eolang.Atom;
+import org.eolang.Attr;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
@@ -56,9 +57,9 @@ public final class EOdom_parser$EOparse_from_string extends PhDefault implements
     @Override
     public Phi lambda() {
         final Phi data = this.take("data");
-        final Phi doc = Phi.Φ.take("org.eolang.dom.doc").copy();
+        final Phi xml = Phi.Φ.take("org.eolang.dom.doc").copy().take(Attr.PHI);
         try {
-            doc.put(
+            xml.put(
                 "data",
                 new Data.ToPhi(
                     new XmlNode.Default(new Dataized(data).asString()).asString().getBytes()
@@ -72,6 +73,6 @@ public final class EOdom_parser$EOparse_from_string extends PhDefault implements
                 exception
             );
         }
-        return doc;
+        return xml;
     }
 }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOwith_attribute.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOwith_attribute.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom; // NOPMD
+
+import org.eolang.AtVoid;
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+import org.w3c.dom.Element;
+
+/**
+ * Element with attribute.
+ * @since 0.0.0
+ */
+@XmirObject(oname = "element.with-attribute")
+public final class EOelement$EOwith_attribute extends PhDefault implements Atom {
+
+    /**
+     * Ctor.
+     */
+    public EOelement$EOwith_attribute() {
+        this.add("attr", new AtVoid("attr"));
+        this.add("value", new AtVoid("value"));
+    }
+
+    @Override
+    public Phi lambda() throws Exception {
+        final Element self = new XmlNode.Default(
+            new Dataized(this.take(Attr.RHO).take("xml")).asString()
+        ).self();
+        self.setAttribute(
+            new Dataized(this.take("attr")).asString(), new Dataized(this.take("value")).asString()
+        );
+        final Phi fresh = Phi.Φ.take("org.eolang.dom.element").copy();
+        fresh.put(
+            "xml",
+            new Data.ToPhi(
+                new XmlNode.Default(self).asString().getBytes()
+            )
+        );
+        return fresh;
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOwith_attribute.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOwith_attribute.java
@@ -40,13 +40,16 @@ import org.w3c.dom.Element;
 /**
  * Element with attribute.
  * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
  */
+@SuppressWarnings("PMD.AvoidDollarSigns")
 @XmirObject(oname = "element.with-attribute")
 public final class EOelement$EOwith_attribute extends PhDefault implements Atom {
 
     /**
      * Ctor.
      */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public EOelement$EOwith_attribute() {
         this.add("attr", new AtVoid("attr"));
         this.add("value", new AtVoid("value"));

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOwith_text.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOwith_text.java
@@ -38,18 +38,18 @@ import org.eolang.XmirObject;
 import org.w3c.dom.Element;
 
 /**
- * Element with attribute.
+ * Element with text content.
+ *
  * @since 0.0.0
  */
-@XmirObject(oname = "element.with-attribute")
-public final class EOelement$EOwith_attribute extends PhDefault implements Atom {
+@XmirObject(oname = "element.with-text")
+public final class EOelement$EOwith_text extends PhDefault implements Atom {
 
     /**
      * Ctor.
      */
-    public EOelement$EOwith_attribute() {
-        this.add("attr", new AtVoid("attr"));
-        this.add("value", new AtVoid("value"));
+    public EOelement$EOwith_text() {
+        this.add("content", new AtVoid("content"));
     }
 
     @Override
@@ -57,9 +57,7 @@ public final class EOelement$EOwith_attribute extends PhDefault implements Atom 
         final Element self = new XmlNode.Default(
             new Dataized(this.take(Attr.RHO).take("xml")).asString()
         ).self();
-        self.setAttribute(
-            new Dataized(this.take("attr")).asString(), new Dataized(this.take("value")).asString()
-        );
+        self.setTextContent(new Dataized(this.take("content")).asString());
         final Phi fresh = Phi.Φ.take("org.eolang.dom.element").copy();
         fresh.put("xml", new Data.ToPhi(new XmlNode.Default(self).asString().getBytes()));
         return fresh;

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOwith_text.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOwith_text.java
@@ -41,13 +41,16 @@ import org.w3c.dom.Element;
  * Element with text content.
  *
  * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
  */
+@SuppressWarnings("PMD.AvoidDollarSigns")
 @XmirObject(oname = "element.with-text")
 public final class EOelement$EOwith_text extends PhDefault implements Atom {
 
     /**
      * Ctor.
      */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public EOelement$EOwith_text() {
         this.add("content", new AtVoid("content"));
     }

--- a/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
@@ -37,6 +37,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -145,6 +146,10 @@ public interface XmlNode {
          */
         Default(final Element element) {
             this.base = element;
+        }
+
+        public Element self() {
+            return this.base;
         }
 
         public NodeList getElementsByTagName(final String name) {

--- a/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
@@ -37,7 +37,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -39,6 +39,19 @@
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?><bar/>"
 
 # This unit test is supposed to check the functionality of the corresponding object.
+[] > appends-element
+  dom-parser.parse-from-string > doc
+    "<foo/>"
+  eq. > @
+    doc.append-child
+      doc.create-element
+        "bar"
+      .with-attribute "f" "x"
+      .with-text "boom"
+    .as-string
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo><bar f=\"x\">boom</bar></foo>"
+
+# This unit test is supposed to check the functionality of the corresponding object.
 [] > retrieves-element-at-index
   dom-parser.parse-from-string > doc
     "<books><book title='Object Thinking'/><book title='Elegant Objects Vol 1.'/></books>"

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -39,6 +39,10 @@
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?><bar/>"
 
 # This unit test is supposed to check the functionality of the corresponding object.
+# @todo #51:45min Make possible to append child node to the empty doc.
+#  It should be possible to append newly created element inside empty document.
+#  In this case, inserted element will be the root element of document. Don't forget
+#  to add EO and Java tests.
 [] > appends-element
   dom-parser.parse-from-string > doc
     "<foo/>"

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -32,10 +32,11 @@
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > creates-element
   eq. > @
-    doc.create-element
-      "foo"
+    dom-parser.parse-from-string
+      "<foo/>"
+    .create-element "bar"
     .as-string
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo/>"
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><bar/>"
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > retrieves-element-at-index

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -30,10 +30,12 @@
 +unlint broken-ref
 
 # This unit test is supposed to check the functionality of the corresponding object.
-[] > creates-simple-document
+[] > creates-element
   eq. > @
-    (doc "<program/>").as-string
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><program/>"
+    doc.create-element
+      "foo"
+    .as-string
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo/>"
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > retrieves-element-at-index

--- a/src/test/eo/org/eolang/dom/element-tests.eo
+++ b/src/test/eo/org/eolang/dom/element-tests.eo
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 +alias org.eolang.dom.element
-+alias org.eolang.dom.doc
++alias org.eolang.dom.dom-parser
 +architect yegor256@gmail.com
 +home https://github.com/h1alexbel/eo-dom
 +tests
@@ -68,8 +68,9 @@
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > creates-element-with-attribute-and-content
   eq. > @
-    doc.create-element
-      "book"
+    dom-parser.parse-from-string
+      "<books/>"
+    .create-element "book"
     .with-attribute "title" "Code Complete"
     .with-attribute "author" "Steve McConnell"
     .with-text "A Practical Handbook of Software Construction"

--- a/src/test/eo/org/eolang/dom/element-tests.eo
+++ b/src/test/eo/org/eolang/dom/element-tests.eo
@@ -46,6 +46,25 @@
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo f=\"123\"/>"
 
 # This unit test is supposed to check the functionality of the corresponding object.
+[] > sets-text-content
+  eq. > @
+    element
+      "<foo/>"
+    .with-text "text is here"
+    .as-string
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo>text is here</foo>"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > builds-element
+  eq. > @
+    element
+      "<book/>"
+    .with-attribute "title" "Object Thinking"
+    .with-text "The greatest book about OOP"
+    .as-string
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><book title=\"Object Thinking\">The greatest book about OOP</book>"
+
+# This unit test is supposed to check the functionality of the corresponding object.
 [] > retrieves-text-content
   eq. > @
     element

--- a/src/test/eo/org/eolang/dom/element-tests.eo
+++ b/src/test/eo/org/eolang/dom/element-tests.eo
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 +alias org.eolang.dom.element
++alias org.eolang.dom.doc
 +architect yegor256@gmail.com
 +home https://github.com/h1alexbel/eo-dom
 +tests
@@ -63,6 +64,17 @@
     .with-text "The greatest book about OOP"
     .as-string
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?><book title=\"Object Thinking\">The greatest book about OOP</book>"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > creates-element-with-attribute-and-content
+  doc.create-element "book" > book
+  eq. > @
+    book
+    .with-attribute "title" "Code Complete"
+    .with-attribute "author" "Steve McConnell"
+    .with-text "A Practical Handbook of Software Construction"
+    .as-string
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><book author=\"Steve McConnell\" title=\"Code Complete\">A Practical Handbook of Software Construction</book>"
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > retrieves-text-content

--- a/src/test/eo/org/eolang/dom/element-tests.eo
+++ b/src/test/eo/org/eolang/dom/element-tests.eo
@@ -67,9 +67,9 @@
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > creates-element-with-attribute-and-content
-  doc.create-element "book" > book
   eq. > @
-    book
+    doc.create-element
+      "book"
     .with-attribute "title" "Code Complete"
     .with-attribute "author" "Steve McConnell"
     .with-text "A Practical Handbook of Software Construction"

--- a/src/test/eo/org/eolang/dom/element-tests.eo
+++ b/src/test/eo/org/eolang/dom/element-tests.eo
@@ -37,6 +37,15 @@
     "ttt"
 
 # This unit test is supposed to check the functionality of the corresponding object.
+[] > sets-attribute
+  eq. > @
+    element
+      "<foo/>"
+    .with-attribute "f" "123"
+    .as-string
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo f=\"123\"/>"
+
+# This unit test is supposed to check the functionality of the corresponding object.
 [] > retrieves-text-content
   eq. > @
     element

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -243,11 +243,11 @@ final class EOdocTest {
      * Finds element with identifier, supplied in DTD.
      *
      * @todo #48:60min Enable this test after `getElementById()` will take an account ID
-     * specified in DTD. Currenlty, we use `org.jsoup` library that checks `id` attribute
-     * in HTML documents by default. Let's make it possible to configure identifiers from
-     * their definitions, supplied in DTD schema. Check
-     * <a href="https://stackoverflow.com/questions/3423430/java-xml-dom-how-are-id-attributes-special">this</a>
-     * for more information about document identifiers.
+     *  specified in DTD. Currenlty, we use `org.jsoup` library that checks `id` attribute
+     *  in HTML documents by default. Let's make it possible to configure identifiers from
+     *  their definitions, supplied in DTD schema. Check
+     *  <a href="https://stackoverflow.com/questions/3423430/java-xml-dom-how-are-id-attributes-special">this</a>
+     *  for more information about document identifiers.
      */
     @Disabled
     @Test

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -28,6 +28,7 @@
 package EOorg.EOeolang.EOdom; // NOPMD
 
 import EOorg.EOeolang.EOerror;
+import org.eolang.Attr;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Phi;
@@ -49,13 +50,13 @@ final class EOdocTest {
 
     @Test
     void createsAnElement() {
-        final Phi doc = Phi.Φ.take("org.eolang.dom.doc");
+        final Phi doc = this.parsedDocument("<x/>");
         final Phi create = doc.take("create-element");
-        create.put("lname", new Data.ToPhi("x"));
+        create.put("lname", new Data.ToPhi("y"));
         MatcherAssert.assertThat(
             "Element XML does not match with expected",
             new Dataized(create.take("as-string")).asString(),
-            Matchers.equalTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?><x/>")
+            Matchers.equalTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?><y/>")
         );
     }
 
@@ -67,7 +68,7 @@ final class EOdocTest {
         }
     )
     void throwsOnInvalidCharacterInCreateElement(final String lname) {
-        final Phi doc = Phi.Φ.take("org.eolang.dom.doc");
+        final Phi doc = this.parsedDocument("<f/>");
         final Phi create = doc.take("create-element");
         create.put("lname", new Data.ToPhi(lname));
         MatcherAssert.assertThat(
@@ -81,6 +82,20 @@ final class EOdocTest {
                 EOerror.ExError.class
             )
         );
+    }
+
+    @Disabled
+    @Test
+    void appendsElementToExistingDocument() {
+        final Phi root = this.parsedDocument("<foo/>");
+        final Phi create = root.take("create-element");
+        create.put("lname", new Data.ToPhi("bar"));
+        final Phi append = root.take("append-child");
+        append.put("child", create);
+        new Dataized(append).asString();
+//        final Phi append = doc.take(Attr.PHI).take("append-child");
+//        append.put("child", create);
+//        new Dataized(append).asString();
     }
 
     @Test

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -28,7 +28,6 @@
 package EOorg.EOeolang.EOdom; // NOPMD
 
 import EOorg.EOeolang.EOerror;
-import org.eolang.Attr;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Phi;
@@ -84,7 +83,6 @@ final class EOdocTest {
         );
     }
 
-    @Disabled
     @Test
     void appendsElementToExistingDocument() {
         final Phi root = this.parsedDocument("<foo/>");
@@ -92,10 +90,13 @@ final class EOdocTest {
         create.put("lname", new Data.ToPhi("bar"));
         final Phi append = root.take("append-child");
         append.put("child", create);
-        new Dataized(append).asString();
-//        final Phi append = doc.take(Attr.PHI).take("append-child");
-//        append.put("child", create);
-//        new Dataized(append).asString();
+        MatcherAssert.assertThat(
+            "Resulted document does not match with expected",
+            new Dataized(append.take("as-string")).asString(),
+            Matchers.equalTo(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo><bar/></foo>"
+            )
+        );
     }
 
     @Test

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -52,6 +52,22 @@ final class EOelementTest {
     }
 
     @Test
+    void setsAttribute() {
+        final Phi with = this.parsed("<foo/>").take("with-attribute");
+        final String set = "f";
+        final String value = "test";
+        with.put("attr", new Data.ToPhi(set));
+        with.put("value", new Data.ToPhi(value));
+        final Phi attr = with.take("get-attribute");
+        attr.put("attr", new Data.ToPhi(set));
+        MatcherAssert.assertThat(
+            "Attribute value does not match with expected",
+            new Dataized(attr).asString(),
+            Matchers.equalTo(value)
+        );
+    }
+
+    @Test
     void retrievesAttribute() {
         final Phi attribute = this.parsed("<foo bar=\"f\"/>").take("get-attribute");
         attribute.put("attr", new Data.ToPhi("bar"));

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.0.0
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class EOelementTest {
 
     @Test
@@ -52,6 +53,7 @@ final class EOelementTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     void setsAttribute() {
         final Phi with = this.parsed("<foo/>").take("with-attribute");
         final String set = "f";
@@ -96,7 +98,7 @@ final class EOelementTest {
         with.put("attr", new Data.ToPhi("set"));
         with.put("value", new Data.ToPhi("v"));
         MatcherAssert.assertThat(
-            "Attribute value does not match with expected",
+            "Result XML does not match with expected",
             new Dataized(with.take("as-string")).asString(),
             Matchers.equalTo(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo set=\"v\"><test><a/></test></foo>"

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -68,6 +68,29 @@ final class EOelementTest {
     }
 
     @Test
+    void createsElementWithAttributeAndText() {
+        final Phi title = this.parsed("<book/>").take("with-attribute");
+        title.put("attr", new Data.ToPhi("title"));
+        title.put("value", new Data.ToPhi("Code Complete"));
+        final Phi author = title.take("with-attribute");
+        author.put("attr", new Data.ToPhi("author"));
+        author.put("value", new Data.ToPhi("Steve McConnell"));
+        final Phi text = author.take("with-text");
+        text.put("content", new Data.ToPhi("A Practical Handbook of Software Construction"));
+        MatcherAssert.assertThat(
+            "Output element does not match with expected",
+            new Dataized(text.take("as-string")).asString().replaceAll("><", ">\n<"),
+            Matchers.equalTo(
+                String.join(
+                    "\n",
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                    "<book author=\"Steve McConnell\" title=\"Code Complete\">A Practical Handbook of Software Construction</book>"
+                )
+            )
+        );
+    }
+
+    @Test
     void setsAttributeToCompositeElement() {
         final Phi with = this.parsed("<foo><test><a/></test></foo>").take("with-attribute");
         with.put("attr", new Data.ToPhi("set"));

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -68,6 +68,20 @@ final class EOelementTest {
     }
 
     @Test
+    void setsAttributeToCompositeElement() {
+        final Phi with = this.parsed("<foo><test><a/></test></foo>").take("with-attribute");
+        with.put("attr", new Data.ToPhi("set"));
+        with.put("value", new Data.ToPhi("v"));
+        MatcherAssert.assertThat(
+            "Attribute value does not match with expected",
+            new Dataized(with.take("as-string")).asString(),
+            Matchers.equalTo(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo set=\"v\"><test><a/></test></foo>"
+            )
+        );
+    }
+
+    @Test
     void retrievesAttribute() {
         final Phi attribute = this.parsed("<foo bar=\"f\"/>").take("get-attribute");
         attribute.put("attr", new Data.ToPhi("bar"));
@@ -88,6 +102,18 @@ final class EOelementTest {
             "Attribute value does not match with expected",
             new Dataized(attribute).asString(),
             Matchers.equalTo("top")
+        );
+    }
+
+    @Test
+    void setsTextContent() {
+        final String content = "bar";
+        final Phi with = this.parsed("<foo/>").take("with-text");
+        with.put("content", new Data.ToPhi(content));
+        MatcherAssert.assertThat(
+            "Attribute value does not match with expected",
+            new Dataized(with.take("text-content")).asString(),
+            Matchers.equalTo(content)
         );
     }
 


### PR DESCRIPTION
In this PR I've implemented `doc.create-element` as the mirror of [Document: createElement()](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement) from JavaScript DOM API. Now it should be possible to create new element from the _existing_ document, and then append it to the base node. Besides that, we added a few new methods for `element` object: `with-attribute`, `with-text`.

closes #51
History:
- **feat(#51): doc.create-element**
- **feat(#51): element.with-attribute**
- **feat(#51): element.with-text**
- **feat(#51): creates-element-with-attribute-and-content**
- **feat(#51): inline**
- **feat(#51): move to doc.xml**
- **feat(#51): append-child**
- **feat(#51): clean for qulice**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the XML DOM manipulation capabilities in the `EOeolang` project by introducing new methods for creating, appending, and modifying elements within XML documents. It includes tests to ensure the functionality of these new features.

### Detailed summary
- Added `self()` method in `XmlNode.java`.
- Introduced new elements in `element.eo` for attributes and text content.
- Updated `EOdom_parser$EOparse_from_string.java` to handle XML with attributes.
- Created `EOdoc$EOxml$EOcreate_element` for creating DOM elements.
- Implemented `EOelement$EOwith_text` and `EOelement$EOwith_attribute` for setting text and attributes.
- Added tests for setting attributes, creating elements, and appending children in `EOelementTest.java` and `EOdocTest.java`. 
- Enhanced error handling for invalid XML characters in the creation of elements.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->