### PR TITLE
feat(#59): `element.child-nodes`

### DIFF
--- a/src/main/eo/org/eolang/dom/element.eo
+++ b/src/main/eo/org/eolang/dom/element.eo
@@ -36,5 +36,8 @@
   [attr value] > with-attribute /org.eolang.dom.element
   # Element with text content.
   [content] > with-text /org.eolang.dom.element
+  # Returns a live list of child nodes of the given element where the first child
+  # node is assigned index 0. Child nodes include elements, text and comments.
+  [] > child-nodes /org.eolang.dom.element
   # Node as-string.
   [] > as-string /org.eolang.dom.element

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOchild_nodes.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOchild_nodes.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom; // NOPMD
+
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * Child nodes of the current element.
+ *
+ * @since 0.0.0
+ */
+@XmirObject(oname = "element.child-nodes")
+public final class EOelement$EOchild_nodes extends PhDefault implements Atom {
+
+    @Override
+    public Phi lambda() throws Exception {
+        return new NodesCollection(
+            new XmlNode.Default(new Dataized(this.take(Attr.RHO).take("xml")).asString())
+                .self().getChildNodes()
+        ).value();
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOchild_nodes.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOchild_nodes.java
@@ -38,7 +38,9 @@ import org.eolang.XmirObject;
  * Child nodes of the current element.
  *
  * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
  */
+@SuppressWarnings("PMD.AvoidDollarSigns")
 @XmirObject(oname = "element.child-nodes")
 public final class EOelement$EOchild_nodes extends PhDefault implements Atom {
 

--- a/src/main/java/EOorg/EOeolang/EOdom/EOhtml_collection$EOlength.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOhtml_collection$EOlength.java
@@ -48,11 +48,14 @@ public final class EOhtml_collection$EOlength extends PhDefault implements Atom 
 
     @Override
     public Phi lambda() throws Exception {
-        return new Data.ToPhi(
-            new ListOf<>(
-                new Dataized(this.take(Attr.RHO).take("nodes"))
-                    .asString().split("\n")
-            ).size()
-        );
+        final int result;
+        final String xml = new Dataized(this.take(Attr.RHO).take("nodes"))
+            .asString();
+        if (xml.isEmpty()) {
+            result = 0;
+        } else {
+            result = new ListOf<>(xml.split("\n")).size();
+        }
+        return new Data.ToPhi(result);
     }
 }

--- a/src/test/eo/org/eolang/dom/element-tests.eo
+++ b/src/test/eo/org/eolang/dom/element-tests.eo
@@ -102,3 +102,12 @@
     .at 0
     .get-attribute "author"
     "David West"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > retrieves-empty-childs
+  eq. > @
+    element
+      "<books/>"
+    .child-nodes
+    .length
+    0

--- a/src/test/eo/org/eolang/dom/element-tests.eo
+++ b/src/test/eo/org/eolang/dom/element-tests.eo
@@ -92,3 +92,13 @@
       "<program/>"
     .text-content
     ""
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > retrieves-child-elements
+  eq. > @
+    element
+      "<books><book author='David West'>Object Thinking</book></books>"
+    .child-nodes
+    .at 0
+    .get-attribute "author"
+    "David West"

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -171,6 +171,58 @@ final class EOelementTest {
         );
     }
 
+    @Test
+    void retrievesChildNodes() {
+        MatcherAssert.assertThat(
+            "Child nodes count does not match with expected",
+            new Dataized(
+                this.parsed("<top><a title='app'/><f>foo</f></top>")
+                    .take("child-nodes")
+                    .take("length")
+            ).asNumber().intValue(),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
+    void retrievesSecondChildNode() {
+        final Phi locate = this.parsed(
+            "<top><foo title='f'>bar</foo><main title='app'>x</main></top>"
+            )
+            .take("child-nodes")
+            .take("at");
+        locate.put("pos", new Data.ToPhi(1));
+        final Phi attr = locate.take("get-attribute");
+        attr.put("attr", new Data.ToPhi("title"));
+        MatcherAssert.assertThat(
+            "Attribute value does not match with expected",
+            new Dataized(attr).asString(),
+            Matchers.equalTo("app")
+        );
+        MatcherAssert.assertThat(
+            "Text inside the node does not match with expected",
+            new Dataized(locate.take("text-content")).asString(),
+            Matchers.equalTo("x")
+        );
+    }
+
+    @Test
+    void retrievesComplexChildNode() {
+        final Phi locate = this.parsed(
+            "<top><child><next n='2'><here title='we are at the bottom'/></next></child></top>"
+            )
+            .take("child-nodes")
+            .take("at");
+        locate.put("pos", new Data.ToPhi(0));
+        MatcherAssert.assertThat(
+            "Resulted child node does not match with expected",
+            new Dataized(locate.take("as-string")).asString(),
+            Matchers.equalTo(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><child><next n=\"2\"><here title=\"we are at the bottom\"/></next></child>"
+            )
+        );
+    }
+
     private Phi parsed(final String xml) {
         final Phi element = Phi.Φ.take("org.eolang.dom.element").copy();
         element.put("xml", new Data.ToPhi(xml));

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -223,6 +223,19 @@ final class EOelementTest {
         );
     }
 
+    @Test
+    void retrievesZeroElementsInChildFreeNode() {
+        MatcherAssert.assertThat(
+            "Size should be zero, since there is no nodes inside",
+            new Dataized(
+                this.parsed("<defects/>")
+                    .take("child-nodes")
+                    .take("length")
+            ).asNumber().intValue(),
+            Matchers.equalTo(0)
+        );
+    }
+
     private Phi parsed(final String xml) {
         final Phi element = Phi.Φ.take("org.eolang.dom.element").copy();
         element.put("xml", new Data.ToPhi(xml));

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -131,6 +131,7 @@ final class EOelementTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     void setsTextContent() {
         final String content = "bar";
         final Phi with = this.parsed("<foo/>").take("with-text");


### PR DESCRIPTION
In this PR I've implemented `.child-nodes` method in `element` object for retrieving child nodes of the current element.

closes #59
History:
- **feat(#59): element.child-nodes**
- **feat(#59): length test**
- **feat(#59): clean for qulice**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces functionality for managing child nodes in the `element` structure of the Eolang DOM. It adds methods to retrieve child nodes and their attributes, improves error handling, and includes unit tests to validate the new features.

### Detailed summary
- Added `child-nodes` method to `org.eolang.dom.element`.
- Enhanced `lambda` method in `EOhtml_collection$EOlength` for better empty string handling.
- Introduced unit tests for retrieving child elements and attributes in `element-tests.eo`.
- Created `EOelement$EOchild_nodes` class for child node management.
- Implemented multiple test cases in `EOelementTest.java` for child node retrieval and attribute access.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->