### PR TITLE
feat(#60): `element.first-child`

### DIFF
--- a/src/main/eo/org/eolang/dom/element.eo
+++ b/src/main/eo/org/eolang/dom/element.eo
@@ -39,5 +39,7 @@
   # Returns a live list of child nodes of the given element where the first child
   # node is assigned index 0. Child nodes include elements, text and comments.
   [] > child-nodes /org.eolang.dom.element
+  # Returns the node's first child in the element tree.
+  [] > first-child /org.eolang.dom.element
   # Node as-string.
   [] > as-string /org.eolang.dom.element

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOfirst_child.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOfirst_child.java
@@ -1,0 +1,35 @@
+package EOorg.EOeolang.EOdom;
+
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+import org.w3c.dom.Element;
+
+/**
+ * First child of the element in the tree.
+ *
+ * @since 0.0.0
+ */
+@XmirObject(oname = "element.first-child")
+public final class EOelement$EOfirst_child extends PhDefault implements Atom {
+
+    @Override
+    public Phi lambda() throws Exception {
+        final Phi elem = Phi.Φ.take("org.eolang.dom.element").copy();
+        elem.put(
+            "xml",
+            new Data.ToPhi(
+                new XmlNode.Default(
+                    (Element)
+                        new XmlNode.Default(new Dataized(this.take(Attr.RHO).take("xml")).asString())
+                            .self().getFirstChild()
+                ).asString().getBytes()
+            )
+        );
+        return elem;
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOfirst_child.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOfirst_child.java
@@ -1,4 +1,31 @@
-package EOorg.EOeolang.EOdom;
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom; // NOPMD
 
 import org.eolang.Atom;
 import org.eolang.Attr;
@@ -13,7 +40,9 @@ import org.w3c.dom.Element;
  * First child of the element in the tree.
  *
  * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
  */
+@SuppressWarnings("PMD.AvoidDollarSigns")
 @XmirObject(oname = "element.first-child")
 public final class EOelement$EOfirst_child extends PhDefault implements Atom {
 
@@ -25,8 +54,9 @@ public final class EOelement$EOfirst_child extends PhDefault implements Atom {
             new Data.ToPhi(
                 new XmlNode.Default(
                     (Element)
-                        new XmlNode.Default(new Dataized(this.take(Attr.RHO).take("xml")).asString())
-                            .self().getFirstChild()
+                        new XmlNode.Default(
+                            new Dataized(this.take(Attr.RHO).take("xml")).asString()
+                        ).self().getFirstChild()
                 ).asString().getBytes()
             )
         );

--- a/src/test/eo/org/eolang/dom/element-tests.eo
+++ b/src/test/eo/org/eolang/dom/element-tests.eo
@@ -111,3 +111,12 @@
     .child-nodes
     .length
     0
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > retrieves-first-child
+  eq. > @
+    element
+      "<films><f>Le Fabuleux destin d'Amélie Poulain</f><f>La haine</f></films>"
+    .first-child
+    .text-content
+    "Le Fabuleux destin d'Amélie Poulain"

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -188,7 +188,7 @@ final class EOelementTest {
     @Test
     void retrievesSecondChildNode() {
         final Phi locate = this.parsed(
-            "<top><foo title='f'>bar</foo><main title='app'>x</main></top>"
+                "<top><foo title='f'>bar</foo><main title='app'>x</main></top>"
             )
             .take("child-nodes")
             .take("at");
@@ -210,7 +210,7 @@ final class EOelementTest {
     @Test
     void retrievesComplexChildNode() {
         final Phi locate = this.parsed(
-            "<top><child><next n='2'><here title='we are at the bottom'/></next></child></top>"
+                "<top><child><next n='2'><here title='we are at the bottom'/></next></child></top>"
             )
             .take("child-nodes")
             .take("at");
@@ -234,6 +234,34 @@ final class EOelementTest {
                     .take("length")
             ).asNumber().intValue(),
             Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    void retrievesFirstChild() {
+        MatcherAssert.assertThat(
+            "First child does not match with expected",
+            new Dataized(
+                this.parsed(
+                    "<top><f>first child is here</f><f>here is the second one</f></top>"
+                ).take("first-child").take("text-content")
+            ).asString(),
+            Matchers.equalTo(
+                "first child is here"
+            )
+        );
+    }
+
+    @Test
+    void returnsXmlHeadIfThereIsNoChildren() {
+        MatcherAssert.assertThat(
+            "Output does not match with expected",
+            new Dataized(
+                this.parsed("<empty/>").take("first-child").take("as-string")
+            ).asString(),
+            Matchers.equalTo(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            )
         );
     }
 

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Test;
 final class EOelementTest {
 
     @Test
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     void printsElement() {
         final String xml = "<abc><c>x</c></abc>";
         MatcherAssert.assertThat(
@@ -188,7 +189,7 @@ final class EOelementTest {
     @Test
     void retrievesSecondChildNode() {
         final Phi locate = this.parsed(
-                "<top><foo title='f'>bar</foo><main title='app'>x</main></top>"
+            "<top><foo title='f'>bar</foo><main title='app'>x</main></top>"
             )
             .take("child-nodes")
             .take("at");
@@ -210,7 +211,7 @@ final class EOelementTest {
     @Test
     void retrievesComplexChildNode() {
         final Phi locate = this.parsed(
-                "<top><child><next n='2'><here title='we are at the bottom'/></next></child></top>"
+            "<top><child><next n='2'><here title='we are at the bottom'/></next></child></top>"
             )
             .take("child-nodes")
             .take("at");


### PR DESCRIPTION
In this PR I've implemented new method for `element` object: `first-child`, that implements [Node.firstChild](https://developer.mozilla.org/en-US/docs/Web/API/Node/firstChild) from JavaScript DOM API.

closes #60
History:
- **feat(#60): element.first-child**
- **feat(#60): clean for qulice**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new feature to retrieve the first child node from an XML element in the `org.eolang.dom.element` structure. It adds functionality to the existing codebase and includes corresponding tests to ensure the new feature works as expected.

### Detailed summary
- Added `first-child` method to `org.eolang.dom.element` to return the first child node.
- Created a unit test `retrieves-first-child` to validate the first child retrieval.
- Added additional test `returnsXmlHeadIfThereIsNoChildren` to check behavior with empty nodes.
- Implemented `EOelement$EOfirst_child` class to define the first child logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->