### PR TITLE
feat(#61): element.last-child

### DIFF
--- a/src/main/eo/org/eolang/dom/element.eo
+++ b/src/main/eo/org/eolang/dom/element.eo
@@ -41,5 +41,7 @@
   [] > child-nodes /org.eolang.dom.element
   # Returns the node's first child in the element tree.
   [] > first-child /org.eolang.dom.element
+  # Returns the node's last child in the element tree.
+  [] > last-child /org.eolang.dom.element
   # Node as-string.
   [] > as-string /org.eolang.dom.element

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOlast_child.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOlast_child.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom; // NOPMD
+
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+import org.w3c.dom.Element;
+
+/**
+ * Find the last child of the given element in the tree.
+ * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
+ */
+@SuppressWarnings("PMD.AvoidDollarSigns")
+@XmirObject(oname = "element.last-child")
+public final class EOelement$EOlast_child extends PhDefault implements Atom {
+
+    @Override
+    public Phi lambda() throws Exception {
+        final Phi elem = Phi.Φ.take("org.eolang.dom.element").copy();
+        elem.put(
+            "xml",
+            new Data.ToPhi(
+                new XmlNode.Default(
+                    (Element)
+                        new XmlNode.Default(
+                            new Dataized(this.take(Attr.RHO).take("xml")).asString()
+                        ).self().getLastChild()
+                ).asString().getBytes()
+            )
+        );
+        return elem;
+    }
+}

--- a/src/test/eo/org/eolang/dom/element-tests.eo
+++ b/src/test/eo/org/eolang/dom/element-tests.eo
@@ -120,3 +120,21 @@
     .first-child
     .text-content
     "Le Fabuleux destin d'Amélie Poulain"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > retrieves-last-child
+  eq. > @
+    element
+      "<films><f>Le Fabuleux destin d'Amélie Poulain</f><f>La haine</f></films>"
+    .last-child
+    .text-content
+    "La haine"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > retrieves-first-element-as-last-child-in-single-child-element
+  eq. > @
+    element
+      "<foo><bar title='23'/></foo>"
+    .last-child
+    .get-attribute "title"
+    "23"

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -33,6 +33,8 @@ import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for {@link EOelement}.
@@ -253,16 +255,35 @@ final class EOelementTest {
         );
     }
 
-    @Test
-    void returnsXmlHeadIfThereIsNoChildren() {
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "first-child",
+            "last-child"
+        }
+    )
+    void returnsXmlHeadIfThereIsNoChildren(final String method) {
         MatcherAssert.assertThat(
             "Output does not match with expected",
             new Dataized(
-                this.parsed("<empty/>").take("first-child").take("as-string")
+                this.parsed("<empty/>").take(method).take("as-string")
             ).asString(),
             Matchers.equalTo(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
             )
+        );
+    }
+
+    @Test
+    void retrievesLastChild() {
+        MatcherAssert.assertThat(
+            "Text node of last child does not match with expected",
+            new Dataized(
+                this.parsed(
+                    "<b><f>first child is here</f><f>here is the last one</f><f>and the last one</f></b>"
+                ).take("last-child").take("text-content")
+            ).asString(),
+            Matchers.equalTo("and the last one")
         );
     }
 


### PR DESCRIPTION
In this PR I've implemented `element.last-child` method from original JavaScript DOM API: [Node.lastChild](https://developer.mozilla.org/en-US/docs/Web/API/Node/lastChild).

closes #61 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `last-child` functionality to the `org.eolang.dom.element`, allowing retrieval of the last child node in an element tree. It also updates tests to validate this new functionality alongside the existing `first-child` method.

### Detailed summary
- Added `last-child` method to `org.eolang.dom.element`.
- Created unit tests for `last-child` in `element-tests.eo`.
- Updated `returnsXmlHeadIfThereIsNoChildren` test to be parameterized for `first-child` and `last-child`.
- Added a new test `retrievesLastChild` in `EOelementTest.java`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->