### PR TITLE
feat(#79): ort

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+name: ort
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  ort:
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oss-review-toolkit/ort-ci-github-action@v1
+        with:
+          fail-on: 'violations'

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+excludes:
+  paths:
+    - comment: It's a test
+      pattern: "src/it/**"
+      reason: BUILD_TOOL_OF
+  scopes:
+    - pattern: "provided"
+      reason: "TEST_DEPENDENCY_OF"
+      comment: "Packages provided"
+    - pattern: "test"
+      reason: "TEST_DEPENDENCY_OF"
+      comment: "Packages for testing only"

--- a/.ort.yml
+++ b/.ort.yml
@@ -2,10 +2,6 @@
 # SPDX-License-Identifier: MIT
 ---
 excludes:
-  paths:
-    - comment: It's a test
-      pattern: "src/it/**"
-      reason: BUILD_TOOL_OF
   scopes:
     - pattern: "provided"
       reason: "TEST_DEPENDENCY_OF"


### PR DESCRIPTION
In this PR I've added [ORT](https://github.com/oss-review-toolkit/ort-ci-github-action?tab=readme-ov-file) to automate compliance checks.

closes #79

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces SPDX licensing information and updates the configuration for the `ort` GitHub Actions workflow, enhancing dependency management and compliance checking.

### Detailed summary
- Added SPDX licensing comments to `.ort.yml` and `.github/workflows/ort.yml`.
- Configured exclusion patterns in `.ort.yml` for "provided" and "test" dependencies.
- Defined the `ort` workflow in `.github/workflows/ort.yml` to trigger on pushes and pull requests to the `master` branch.
- Set the job to run on `ubuntu-24.04` with a timeout of 15 minutes.
- Included steps to check out the code and run the `oss-review-toolkit/ort-ci-github-action`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->