### PR TITLE
feat(#69): xembly, document idents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,12 @@
       <version>0.25</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.jcabi.incubator</groupId>
+      <artifactId>xembly</artifactId>
+      <version>0.32.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -193,7 +199,6 @@
             <artifactId>qulice-maven-plugin</artifactId>
             <version>0.24.0</version>
             <configuration>
-              <license>file:${basedir}/LICENSE.txt</license>
               <excludes>
                 <exclude>pmd:/src/it/.*</exclude>
                 <exclude>checkstyle:/src/it/.*</exclude>

--- a/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
@@ -13,6 +13,8 @@ import java.io.IOException;
 import java.io.StringWriter;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -176,7 +178,10 @@ public interface XmlNode {
         public String asString() {
             final StringWriter writer = new StringWriter();
             try {
-                TransformerFactory.newInstance().newTransformer().transform(
+                final Transformer transformer = TransformerFactory.newInstance().newTransformer();
+                transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+                transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+                transformer.transform(
                     new DOMSource(this.base), new StreamResult(writer)
                 );
             } catch (final TransformerException exception) {

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -16,7 +16,10 @@
       "<foo/>"
     .create-element "bar"
     .as-string
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><bar/>"
+    """
+    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <bar/>\n
+    """
 
 # This unit test is supposed to check the functionality of the corresponding object.
 # @todo #51:45min Make possible to append child node to the empty doc.
@@ -33,7 +36,12 @@
       .with-attribute "f" "x"
       .with-text "boom"
     .as-string
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo><bar f=\"x\">boom</bar></foo>"
+    """
+    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <foo>
+       <bar f=\"x\">boom</bar>
+    </foo>\n
+    """
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > retrieves-element-at-index

--- a/src/test/eo/org/eolang/dom/dom-parser-tests.eo
+++ b/src/test/eo/org/eolang/dom/dom-parser-tests.eo
@@ -14,4 +14,9 @@
     "<books><book title=\"Object Thinking\"/></books>"
   eq. > @
     doc.as-string
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><books><book title=\"Object Thinking\"/></books>"
+    """
+    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <books>
+       <book title=\"Object Thinking\"/>
+    </books>\n
+    """

--- a/src/test/eo/org/eolang/dom/element-tests.eo
+++ b/src/test/eo/org/eolang/dom/element-tests.eo
@@ -24,7 +24,10 @@
       "<foo/>"
     .with-attribute "f" "123"
     .as-string
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo f=\"123\"/>"
+    """
+    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <foo f=\"123\"/>\n
+    """
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > sets-text-content
@@ -33,7 +36,10 @@
       "<foo/>"
     .with-text "text is here"
     .as-string
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo>text is here</foo>"
+    """
+    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <foo>text is here</foo>\n
+    """
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > builds-element
@@ -43,7 +49,10 @@
     .with-attribute "title" "Object Thinking"
     .with-text "The greatest book about OOP"
     .as-string
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><book title=\"Object Thinking\">The greatest book about OOP</book>"
+    """
+    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <book title=\"Object Thinking\">The greatest book about OOP</book>\n
+    """
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > creates-element-with-attribute-and-content
@@ -55,7 +64,10 @@
     .with-attribute "author" "Steve McConnell"
     .with-text "A Practical Handbook of Software Construction"
     .as-string
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><book author=\"Steve McConnell\" title=\"Code Complete\">A Practical Handbook of Software Construction</book>"
+    """
+    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <book author=\"Steve McConnell\" title=\"Code Complete\">A Practical Handbook of Software Construction</book>\n
+    """
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > retrieves-text-content

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdom_parserTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdom_parserTest.java
@@ -16,6 +16,9 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Throws;
+import org.xembly.Directives;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
 
 /**
  * Tests for {@link EOdom_parser}.
@@ -26,14 +29,16 @@ import org.llorllale.cactoos.matchers.Throws;
 final class EOdom_parserTest {
 
     @Test
-    void parsersStringIntoDocument() {
+    void parsersStringIntoDocument() throws ImpossibleModificationException {
         final Phi parse = this.parser("<books><book title=\"Object Thinking\"/></books>");
         final Phi doc = parse.take("as-string");
         MatcherAssert.assertThat(
             "Parsed document doesn't match with expected",
             new Dataized(doc).asString(),
             Matchers.equalTo(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><books><book title=\"Object Thinking\"/></books>"
+                new Xembler(
+                    new Directives().add("books").add("book").attr("title", "Object Thinking")
+                ).xml()
             )
         );
     }

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -254,7 +254,8 @@ final class EOelementTest {
             "last-child"
         }
     )
-    void returnsXmlHeadIfThereIsNoChildren(final String method) throws ImpossibleModificationException {
+    void returnsXmlHeadIfThereIsNoChildren(final String method)
+        throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "Output does not match with expected",
             new Dataized(

--- a/src/test/java/EOorg/EOeolang/EOdom/XmlNodeTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/XmlNodeTest.java
@@ -12,6 +12,9 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Throws;
+import org.xembly.Directives;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
 
 /**
  * Tests for {@link XmlNode}.
@@ -22,13 +25,18 @@ import org.llorllale.cactoos.matchers.Throws;
 final class XmlNodeTest {
 
     @Test
-    void parsesDocumentFromString() throws XmlParseException {
+    void parsesDocumentFromString() throws XmlParseException, ImpossibleModificationException {
         MatcherAssert.assertThat(
             "Parsed document doesn't match with expected",
             new XmlNode.Default("<program><test foo=\"f\">bar</test></program>")
                 .elem("program").elem("test").asString(),
             Matchers.equalTo(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><test foo=\"f\">bar</test>"
+                new Xembler(
+                    new Directives()
+                        .add("test")
+                        .attr("foo", "f")
+                        .set("bar")
+                ).xml()
             )
         );
     }
@@ -43,13 +51,15 @@ final class XmlNodeTest {
     }
 
     @Test
-    void parsesNodeFromNextElement() throws XmlParseException {
+    void parsesNodeFromNextElement() throws XmlParseException, ImpossibleModificationException {
         MatcherAssert.assertThat(
             "Parsed document doesn't match with expected",
             new XmlNode.Default("<program><test foo=\"f\">bar</test></program>")
                 .elem("test").asString(),
             Matchers.equalTo(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><test foo=\"f\">bar</test>"
+                new Xembler(
+                    new Directives().add("test").attr("foo", "f").set("bar")
+                ).xml()
             )
         );
     }

--- a/src/test/java/EOorg/EOeolang/EOdom/XmlNodeTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/XmlNodeTest.java
@@ -28,12 +28,12 @@ final class XmlNodeTest {
     void parsesDocumentFromString() throws XmlParseException, ImpossibleModificationException {
         MatcherAssert.assertThat(
             "Parsed document doesn't match with expected",
-            new XmlNode.Default("<program><test foo=\"f\">bar</test></program>")
-                .elem("program").elem("test").asString(),
+            new XmlNode.Default("<program><a foo=\"f\">bar</a></program>")
+                .elem("program").elem("a").asString(),
             Matchers.equalTo(
                 new Xembler(
                     new Directives()
-                        .add("test")
+                        .add("a")
                         .attr("foo", "f")
                         .set("bar")
                 ).xml()


### PR DESCRIPTION
In this PR I've added [xembly](https://github.com/yegor256/xembly) for complex document comparison in tests, and configured indentation for document printing in `asString()`.

closes #69
History:
- **feat(#69): xembly, document idents**
- **feat(#69): clean for qulice**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the XML formatting in various tests and enhancing the `EOdom` and `EOelement` functionalities by incorporating the `xembly` library for XML manipulation.

### Detailed summary
- Updated XML strings in tests to be more readable with line breaks.
- Added `xembly` dependency to `pom.xml`.
- Enhanced exception handling in parser tests.
- Refactored XML creation in tests using `Xembler` for consistency.
- Modified test methods to throw `ImpossibleModificationException`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->