### PR TITLE
bug(#87): upgrade EO 0.53.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.52.0</version>
+        <version>0.53.0</version>
         <configuration>
           <foreign>${project.build.directory}/eo-foreign.csv</foreign>
           <foreignFormat>csv</foreignFormat>
@@ -133,9 +133,7 @@
             <id>compile</id>
             <goals>
               <goal>register</goal>
-              <goal>deps</goal>
-              <goal>assemble</goal>
-              <goal>lint</goal>
+              <goal>compile</goal>
               <goal>transpile</goal>
               <goal>xmir-to-phi</goal>
               <goal>phi-to-xmir</goal>
@@ -154,6 +152,7 @@
                   same in `test-compile` execution.
               -->
               <failOnWarning>false</failOnWarning>
+              <skipLinting>true</skipLinting>
             </configuration>
           </execution>
           <execution>
@@ -161,9 +160,7 @@
             <phase>generate-test-sources</phase>
             <goals>
               <goal>register</goal>
-              <goal>deps</goal>
-              <goal>assemble</goal>
-              <goal>lint</goal>
+              <goal>compile</goal>
               <goal>xmir-to-phi</goal>
               <goal>phi-to-xmir</goal>
               <goal>transpile</goal>
@@ -178,10 +175,11 @@
               <unphiOutputDir>${project.build.directory}/eo-test/unphi</unphiOutputDir>
               <addSourcesRoot>false</addSourcesRoot>
               <addTestSourcesRoot>true</addTestSourcesRoot>
-              <failOnWarning>false</failOnWarning>
               <generatedDir>${project.build.directory}/generated-test-sources</generatedDir>
               <withRuntimeDependency>true</withRuntimeDependency>
               <placeBinariesThatHaveSources>true</placeBinariesThatHaveSources>
+              <failOnWarning>false</failOnWarning>
+              <skipLinting>true</skipLinting>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,6 @@
                   same in `test-compile` execution.
               -->
               <failOnWarning>false</failOnWarning>
-              <skipLinting>true</skipLinting>
             </configuration>
           </execution>
           <execution>
@@ -179,7 +178,6 @@
               <withRuntimeDependency>true</withRuntimeDependency>
               <placeBinariesThatHaveSources>true</placeBinariesThatHaveSources>
               <failOnWarning>false</failOnWarning>
-              <skipLinting>true</skipLinting>
             </configuration>
           </execution>
         </executions>

--- a/src/main/eo/org/eolang/dom/doc.eo
+++ b/src/main/eo/org/eolang/dom/doc.eo
@@ -10,20 +10,20 @@
 # an entry-point into the XML-based document's content.
 [] > doc
   # XML.
-  [data] > @ /org.eolang.dom.doc.xml
+  [data] > @ ?
 
   # Serialized XML.
   [serialized] > xml
-    [name] > get-elements-by-tag-name /org.eolang.dom.doc.xml
+    [name] > get-elements-by-tag-name ?
     # Retrieves a list of elements with the given tag name belonging to the given namespace.
     # The complete document is searched, including the root node.
-    [ns name] > get-elements-by-tag-name-ns /org.eolang.dom.doc.xml
+    [ns name] > get-elements-by-tag-name-ns ?
     # Returns an element whose id property matches the specified string.
     # Since element IDs are required to be unique if specified, they're a
     # useful way to get access to a specific element quickly.
-    [identifier] > get-element-by-id /org.eolang.dom.doc.xml
-    [] > as-string /org.eolang.string
+    [identifier] > get-element-by-id ?
+    [] > as-string ?
     # Creates the DOM element specified by `lname`.
-    [lname] > create-element /org.eolang.dom.doc.xml
+    [lname] > create-element ?
     # Appends child to DOM document.
-    [child] > append-child /org.eolang.dom.doc
+    [child] > append-child ?

--- a/src/main/eo/org/eolang/dom/doc.eo
+++ b/src/main/eo/org/eolang/dom/doc.eo
@@ -5,6 +5,7 @@
 +package org.eolang.dom
 +rt jvm org.eolang:eo-runtime:0.0.0
 +version 0.0.0
++also string
 
 # The doc object allows you to create XML tree-based documents. Serves as
 # an entry-point into the XML-based document's content.

--- a/src/main/eo/org/eolang/dom/doc.eo
+++ b/src/main/eo/org/eolang/dom/doc.eo
@@ -6,6 +6,7 @@
 +rt jvm org.eolang:eo-runtime:0.0.0
 +version 0.0.0
 +also string
++unlint rt-without-atoms
 
 # The doc object allows you to create XML tree-based documents. Serves as
 # an entry-point into the XML-based document's content.

--- a/src/main/eo/org/eolang/dom/dom-parser.eo
+++ b/src/main/eo/org/eolang/dom/dom-parser.eo
@@ -10,4 +10,4 @@
 # code from a string into a DOM Document.
 [] > dom-parser
   # Parse string into a DOM document.
-  [data] > parse-from-string /org.eolang.dom.doc
+  [data] > parse-from-string ?

--- a/src/main/eo/org/eolang/dom/dom-parser.eo
+++ b/src/main/eo/org/eolang/dom/dom-parser.eo
@@ -6,6 +6,7 @@
 +rt jvm org.eolang:eo-runtime:0.0.0
 +version 0.0.0
 +also string
++unlint rt-without-atoms
 
 # The DOM Parser object, that provides the ability to parse XML or HTML source
 # code from a string into a DOM Document.

--- a/src/main/eo/org/eolang/dom/dom-parser.eo
+++ b/src/main/eo/org/eolang/dom/dom-parser.eo
@@ -5,6 +5,7 @@
 +package org.eolang.dom
 +rt jvm org.eolang:eo-runtime:0.0.0
 +version 0.0.0
++also string
 
 # The DOM Parser object, that provides the ability to parse XML or HTML source
 # code from a string into a DOM Document.

--- a/src/main/eo/org/eolang/dom/element.eo
+++ b/src/main/eo/org/eolang/dom/element.eo
@@ -5,6 +5,7 @@
 +package org.eolang.dom
 +rt jvm org.eolang:eo-runtime:0.0.0
 +version 0.0.0
++also string
 
 # Object that represent element inside DOM Document.
 [xml] > element

--- a/src/main/eo/org/eolang/dom/element.eo
+++ b/src/main/eo/org/eolang/dom/element.eo
@@ -6,6 +6,7 @@
 +rt jvm org.eolang:eo-runtime:0.0.0
 +version 0.0.0
 +also string
++unlint rt-without-atoms
 
 # Object that represent element inside DOM Document.
 [xml] > element

--- a/src/main/eo/org/eolang/dom/element.eo
+++ b/src/main/eo/org/eolang/dom/element.eo
@@ -9,19 +9,19 @@
 # Object that represent element inside DOM Document.
 [xml] > element
   # Attribute.
-  [attr] > get-attribute /org.eolang.dom.element
+  [attr] > get-attribute ?
   # Text content inside element.
-  [] > text-content /org.eolang.dom.element
+  [] > text-content ?
   # Element with attribute.
-  [attr value] > with-attribute /org.eolang.dom.element
+  [attr value] > with-attribute ?
   # Element with text content.
-  [content] > with-text /org.eolang.dom.element
+  [content] > with-text ?
   # Returns a live list of child nodes of the given element where the first child
   # node is assigned index 0. Child nodes include elements, text and comments.
-  [] > child-nodes /org.eolang.dom.element
+  [] > child-nodes ?
   # Returns the node's first child in the element tree.
-  [] > first-child /org.eolang.dom.element
+  [] > first-child ?
   # Returns the node's last child in the element tree.
-  [] > last-child /org.eolang.dom.element
+  [] > last-child ?
   # Node as-string.
-  [] > as-string /org.eolang.dom.element
+  [] > as-string ?

--- a/src/main/eo/org/eolang/dom/html-collection.eo
+++ b/src/main/eo/org/eolang/dom/html-collection.eo
@@ -6,6 +6,7 @@
 +rt jvm org.eolang:eo-runtime:0.0.0
 +version 0.0.0
 +also string
++unlint rt-without-atoms
 
 # HTML collection that represents a generic collection of elements (in document order)
 # and offers methods and properties for selecting from the list.

--- a/src/main/eo/org/eolang/dom/html-collection.eo
+++ b/src/main/eo/org/eolang/dom/html-collection.eo
@@ -10,6 +10,6 @@
 # and offers methods and properties for selecting from the list.
 [nodes] > html-collection
   # At.
-  [pos] > at /org.eolang.dom.html-collection
+  [pos] > at ?
   # Lenght of the current collection.
-  [] > length /org.eolang.dom.html-collection
+  [] > length ?

--- a/src/main/eo/org/eolang/dom/html-collection.eo
+++ b/src/main/eo/org/eolang/dom/html-collection.eo
@@ -5,6 +5,7 @@
 +package org.eolang.dom
 +rt jvm org.eolang:eo-runtime:0.0.0
 +version 0.0.0
++also string
 
 # HTML collection that represents a generic collection of elements (in document order)
 # and offers methods and properties for selecting from the list.

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -6,7 +6,6 @@
 +tests
 +package org.eolang.dom
 +version 0.0.0
-+unlint broken-ref
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > creates-element

--- a/src/test/eo/org/eolang/dom/dom-parser-tests.eo
+++ b/src/test/eo/org/eolang/dom/dom-parser-tests.eo
@@ -6,7 +6,6 @@
 +tests
 +package org.eolang.dom
 +version 0.0.0
-+unlint broken-ref
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > parses-string-into-document

--- a/src/test/eo/org/eolang/dom/element-tests.eo
+++ b/src/test/eo/org/eolang/dom/element-tests.eo
@@ -7,7 +7,6 @@
 +tests
 +package org.eolang.dom
 +version 0.0.0
-+unlint broken-ref
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > retrieves-attribute-from-element


### PR DESCRIPTION
In this PR I've upgraded EO-maven-plugin to 0.53.0, which affected atoms functionality.

closes #87

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `org.eolang.dom` package by adding versioning, adjusting method signatures to use `?` for unspecified parameters, and modifying the `pom.xml` for dependency management. 

### Detailed summary
- Added `package org.eolang.dom` and `version 0.0.0` to multiple files.
- Changed method signatures in various files to use `?`.
- Updated `pom.xml` version from `0.52.0` to `0.53.0`.
- Removed `lint` and `assemble` goals from the build configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->