### PR TITLE
bug(#62): disabled tests with recursive children retrieval

### DIFF
--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -13,6 +13,7 @@ import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -277,6 +278,35 @@ final class EOelementTest {
                 ).take("last-child").take("text-content")
             ).asString(),
             Matchers.equalTo("and the last one")
+        );
+    }
+
+    /**
+     * Retrieves children recursively.
+     * @param direction Direction
+     * @throws ImpossibleModificationException if something went wrong.
+     * @todo #62:60min Enable this test when recursive retrieval of first children will work.
+     *  Currently, it does not work due to next found element denoted as
+     *  {@link com.sun.org.apache.xerces.internal.dom.DeferredTextImpl} instead of
+     *  {@link org.w3c.dom.Element}. We should resolve that, and enable this test.
+     */
+    @Disabled
+    @ParameterizedTest
+    @ValueSource(strings = {"first-child", "last-child"})
+    void retrievesChildrenRecursively(final String direction)
+        throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "First child does not match with expected",
+            new Dataized(
+                this.parsed("<parent><a><b><c>finally we are here</c></b></a></parent>")
+                    .take(direction)
+                    .take(direction)
+                    .take(direction)
+                    .take("as-string")
+            ).asString(),
+            Matchers.equalTo(
+                new Xembler(new Directives().add("c").set("finally we are here")).xml()
+            )
         );
     }
 


### PR DESCRIPTION
In this PR I've added disabled test for bug with recursive children retrieval via `element.first-child` and `element.last-child`.

see #62
