### PR TITLE
bug(#90): recursive child retrieval

### DIFF
--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOfirst_child.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOfirst_child.java
@@ -15,7 +15,6 @@ import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
-import org.w3c.dom.Element;
 
 /**
  * First child of the element in the tree.
@@ -34,10 +33,9 @@ public final class EOelement$EOfirst_child extends PhDefault implements Atom {
             "xml",
             new Data.ToPhi(
                 new XmlNode.Default(
-                    (Element)
-                        new XmlNode.Default(
-                            new Dataized(this.take(Attr.RHO).take("xml")).asString()
-                        ).self().getFirstChild()
+                    new XmlNode.Default(
+                        new Dataized(this.take(Attr.RHO).take("xml")).asString()
+                    ).getFirstChild()
                 ).asString().getBytes()
             )
         );

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOlast_child.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOlast_child.java
@@ -15,7 +15,6 @@ import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
-import org.w3c.dom.Element;
 
 /**
  * Find the last child of the given element in the tree.
@@ -33,10 +32,9 @@ public final class EOelement$EOlast_child extends PhDefault implements Atom {
             "xml",
             new Data.ToPhi(
                 new XmlNode.Default(
-                    (Element)
-                        new XmlNode.Default(
-                            new Dataized(this.take(Attr.RHO).take("xml")).asString()
-                        ).self().getLastChild()
+                    new XmlNode.Default(
+                        new Dataized(this.take(Attr.RHO).take("xml")).asString()
+                    ).getLastChild()
                 ).asString().getBytes()
             )
         );

--- a/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
@@ -20,6 +20,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -134,6 +135,22 @@ public interface XmlNode {
             return this.base;
         }
 
+        public Element getFirstChild() {
+            Node node = this.self().getFirstChild();
+            while (node != null && (int) node.getNodeType() == (int) Node.TEXT_NODE) {
+                node = node.getNextSibling();
+            }
+            return (Element) node;
+        }
+
+        public Element getLastChild() {
+            Node node = this.self().getLastChild();
+            while (node != null && (int) node.getNodeType() == (int) Node.TEXT_NODE) {
+                node = node.getPreviousSibling();
+            }
+            return (Element) node;
+        }
+
         public NodeList getElementsByTagName(final String name) {
             return this.base.getElementsByTagName(name);
         }
@@ -201,9 +218,11 @@ public interface XmlNode {
             try {
                 final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
                 dbf.setNamespaceAware(true);
-                return dbf.newDocumentBuilder()
+                final Element doc = dbf.newDocumentBuilder()
                     .parse(new ByteArrayInputStream(xml.getBytes()))
                     .getDocumentElement();
+                doc.normalize();
+                return doc;
             } catch (final ParserConfigurationException exception) {
                 throw new IllegalStateException(
                     String.format(

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -13,7 +13,6 @@ import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -281,16 +280,6 @@ final class EOelementTest {
         );
     }
 
-    /**
-     * Retrieves children recursively.
-     * @param direction Direction
-     * @throws ImpossibleModificationException if something went wrong.
-     * @todo #62:60min Enable this test when recursive retrieval of first children will work.
-     *  Currently, it does not work due to next found element denoted as
-     *  {@link com.sun.org.apache.xerces.internal.dom.DeferredTextImpl} instead of
-     *  {@link org.w3c.dom.Element}. We should resolve that, and enable this test.
-     */
-    @Disabled
     @ParameterizedTest
     @ValueSource(strings = {"first-child", "last-child"})
     void retrievesChildrenRecursively(final String direction)


### PR DESCRIPTION
In this PR I've fixed bug with recursive child retrieval via `element-first-child`, `element-last-child`.

closes #90

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of first and last child elements in the XML processing classes by removing unnecessary type casting and adding new methods for retrieving these elements.

### Detailed summary
- Removed unnecessary `(Element)` type casting in `lambda()` methods of `EOelement$EOfirst_child.java` and `EOelement$EOlast_child.java`.
- Added `getFirstChild()` and `getLastChild()` methods in `XmlNode` class to retrieve non-text child elements.
- Cleaned up the test code by removing a disabled test method in `EOelementTest.java`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->