### PR TITLE
feat(#63): `element.previous-sibling`

### DIFF
--- a/src/main/eo/org/eolang/dom/element.eo
+++ b/src/main/eo/org/eolang/dom/element.eo
@@ -17,7 +17,7 @@
   # @todo #62:60min Set nsib attribute everywhere where its possible to chain
   #  element navigation, and retrieve next-sibling from result. Don't forget to
   #  add EO and Atom tests.
-  [src parent nsib] > serialized
+  [src parent nsib psib] > serialized
     # Attribute.
     [attr] > get-attribute ?
     # Text content inside element.
@@ -37,5 +37,7 @@
     [] > parent-node ?
     # Next sibling.
     [] > next-sibling ?
+    # Previous sibling.
+    [] > previous-sibling ?
     # Node as-string.
     [] > as-string ?

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOserialized$EOlast_child.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOserialized$EOlast_child.java
@@ -47,6 +47,12 @@ public final class EOelement$EOserialized$EOlast_child extends PhDefault impleme
                         .getBytes()
                 )
             );
+            elem.put(
+                "psib",
+                new Data.ToPhi(
+                    new XmlNode.Default(source.getPreviousSibling()).asString().getBytes()
+                )
+            );
         }
         return elem;
     }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOserialized$EOnext_sibling.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOserialized$EOnext_sibling.java
@@ -48,6 +48,14 @@ public final class EOelement$EOserialized$EOnext_sibling extends PhDefault imple
                     )
                 );
             }
+            if (sibled.getPreviousSibling() != null) {
+                elem.put(
+                    "psib",
+                    new Data.ToPhi(
+                        new XmlNode.Default(sibled.getPreviousSibling()).asString().getBytes()
+                    )
+                );
+            }
         }
         return elem;
     }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOserialized$EOprevious_sibling.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOserialized$EOprevious_sibling.java
@@ -43,11 +43,13 @@ public final class EOelement$EOserialized$EOprevious_sibling extends PhDefault i
                 elem.put(
                     "psib",
                     new Data.ToPhi(
-                        new XmlNode.Default(sibled.getPreviousSibling())
-                            .asString().getBytes()
+                        new XmlNode.Default(sibled.getPreviousSibling()).asString().getBytes()
                     )
                 );
             }
+            elem.put(
+                "nsib", new Data.ToPhi(sibled.asString().getBytes())
+            );
         }
         return elem;
     }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOserialized$EOprevious_sibling.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOelement$EOserialized$EOprevious_sibling.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom; // NOPMD
+
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * Previous sibling of the current node.
+ * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
+ */
+@SuppressWarnings("PMD.AvoidDollarSigns")
+@XmirObject(oname = "element.previous-sibling")
+public final class EOelement$EOserialized$EOprevious_sibling extends PhDefault implements Atom {
+
+    @Override
+    public Phi lambda() throws Exception {
+        final Phi elem = Phi.Φ.take("org.eolang.dom.element").take("serialized").copy();
+        final XmlNode.Default source = new XmlNode.Default(
+            new Dataized(this.take(Attr.RHO).take("psib")).asString()
+        );
+        final XmlNode.Default parent = new XmlNode.Default(
+            new Dataized(this.take(Attr.RHO).take("parent")).asString()
+        );
+        elem.put("src", new Data.ToPhi(source.asString().getBytes()));
+        elem.put("parent", new Data.ToPhi(parent.asString().getBytes()));
+        final XmlNode.Default last = new XmlNode.Default(parent.getLastChild());
+        if (last.getPreviousSibling() != null) {
+            final XmlNode.Default sibled = new XmlNode.Default(last.getPreviousSibling());
+            if (sibled.getPreviousSibling() != null) {
+                elem.put(
+                    "psib",
+                    new Data.ToPhi(
+                        new XmlNode.Default(sibled.getPreviousSibling())
+                            .asString().getBytes()
+                    )
+                );
+            }
+        }
+        return elem;
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
@@ -167,6 +167,14 @@ public interface XmlNode {
             return (Element) node;
         }
 
+        public Element getPreviousSibling() {
+            Node node = this.self().getPreviousSibling();
+            while (node != null && (int) node.getNodeType() == (int) Node.TEXT_NODE) {
+                node = node.getPreviousSibling();
+            }
+            return (Element) node;
+        }
+
         public NodeList getElementsByTagName(final String name) {
             return this.base.getElementsByTagName(name);
         }

--- a/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/XmlNode.java
@@ -33,6 +33,7 @@ import org.xml.sax.SAXException;
  *  Now, we should refactor and decompose this interface to present basic DOM element
  *  with an entry point to W3C API.
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public interface XmlNode {
 
     /**

--- a/src/test/eo/org/eolang/dom/element-tests.eo
+++ b/src/test/eo/org/eolang/dom/element-tests.eo
@@ -138,3 +138,27 @@ eq. > navigates-through-siblings
   .next-sibling
   .get-attribute "name"
   "Rib-eye"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+eq. > goes-back-and-forth-from-last-child
+  element.serialized
+    "<groceries><g name='Cottage Cheese'/><g name='Soy Protein'/><g name='Avocado'/></groceries>"
+  .last-child
+  .previous-sibling
+  .previous-sibling
+  .next-sibling
+  .previous-sibling
+  .get-attribute "name"
+  "Cottage Cheese"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+eq. > goes-back-and-forth-from-first-child
+  element.serialized
+    "<groceries><g name='Cottage Cheese'/><g name='Soy Protein'/><g name='Avocado'/></groceries>"
+  .first-child
+  .next-sibling
+  .next-sibling
+  .previous-sibling
+  .previous-sibling
+  .get-attribute "name"
+  "Cottage Cheese"

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -341,6 +341,7 @@ final class EOelementTest {
         );
     }
 
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     @Test
     void retrievesNextSibling() {
         final Phi attribute = this.parsed("<a><b x='ttt'/><b x='boom'/></a>")
@@ -370,6 +371,7 @@ final class EOelementTest {
         );
     }
 
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     @Test
     void retrievesPreviousSiblings() {
         final Phi attr = this.parsed("<set><a name='A'/><b name='B'/><c name='C'/></set>")
@@ -386,18 +388,36 @@ final class EOelementTest {
     }
 
     @Test
-    void goesBackAndForthWithSiblings() {
+    void goesBackAndForthWithSiblingsFromLastChild() {
         final Phi attr = this.parsed("<set><a name='A'/><b name='B'/><c name='C'/></set>")
             .take("last-child")
             .take("previous-sibling")
             .take("previous-sibling")
             .take("next-sibling")
+            .take("previous-sibling")
             .take("get-attribute");
         attr.put("attr", new Data.ToPhi("name"));
         MatcherAssert.assertThat(
             "Attribute value of the retrieved node does not match with expected",
             new Dataized(attr).asString(),
-            Matchers.equalTo("B")
+            Matchers.equalTo("A")
+        );
+    }
+
+    @Test
+    void goesBackAndForthWithSiblingsFromFirstChild() {
+        final Phi attr = this.parsed("<films><f id='1'/><f id='2'/><f id='3'/></films>")
+            .take("first-child")
+            .take("next-sibling")
+            .take("next-sibling")
+            .take("previous-sibling")
+            .take("previous-sibling")
+            .take("get-attribute");
+        attr.put("attr", new Data.ToPhi("id"));
+        MatcherAssert.assertThat(
+            "Attribute value of the retrieved node does not match with expected",
+            new Dataized(attr).asString(),
+            Matchers.equalTo("1")
         );
     }
 

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -370,6 +370,21 @@ final class EOelementTest {
         );
     }
 
+    @Test
+    void retrievesPreviousSiblings() {
+        final Phi attr = this.parsed("<set><a name='A'/><b name='B'/><c name='C'/></set>")
+            .take("last-child")
+            .take("previous-sibling")
+            .take("previous-sibling")
+            .take("get-attribute");
+        attr.put("attr", new Data.ToPhi("name"));
+        MatcherAssert.assertThat(
+            "Attribute value of the retrieved node does not match with expected",
+            new Dataized(attr).asString(),
+            Matchers.equalTo("A")
+        );
+    }
+
     private Phi parsed(final String xml) {
         final Phi element = Phi.Φ.take("org.eolang.dom.element").take(Attr.PHI).copy();
         element.put("xml", new Data.ToPhi(xml));

--- a/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOelementTest.java
@@ -385,6 +385,22 @@ final class EOelementTest {
         );
     }
 
+    @Test
+    void goesBackAndForthWithSiblings() {
+        final Phi attr = this.parsed("<set><a name='A'/><b name='B'/><c name='C'/></set>")
+            .take("last-child")
+            .take("previous-sibling")
+            .take("previous-sibling")
+            .take("next-sibling")
+            .take("get-attribute");
+        attr.put("attr", new Data.ToPhi("name"));
+        MatcherAssert.assertThat(
+            "Attribute value of the retrieved node does not match with expected",
+            new Dataized(attr).asString(),
+            Matchers.equalTo("B")
+        );
+    }
+
     private Phi parsed(final String xml) {
         final Phi element = Phi.Φ.take("org.eolang.dom.element").take(Attr.PHI).copy();
         element.put("xml", new Data.ToPhi(xml));


### PR DESCRIPTION
In this PR I've implemented `element.previous-sibling` from [JavaScript DOM API](https://developer.mozilla.org/en-US/docs/Web/API/Node/previousSibling).

closes #63
History:
- **feat(#63): previous.sibling**
- **feat(#63): goesBackAndForthWithSiblings**
- **feat(#63): more tests**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `EOelement` class functionality by adding support for retrieving the previous sibling of an XML element. It includes new methods, updates to the serialization process, and corresponding tests to ensure the new behavior works correctly.

### Detailed summary
- Added `getPreviousSibling()` method in `XmlNode` interface.
- Implemented `EOelement$EOserialized$EOprevious_sibling` class to handle previous sibling retrieval.
- Updated `element.eo` to include `previous-sibling` navigation.
- Enhanced tests in `EOelementTest` to verify previous sibling functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->