### PR TITLE
feat(#53): `doc.evaluate`

### DIFF
--- a/src/main/eo/org/eolang/dom/doc.eo
+++ b/src/main/eo/org/eolang/dom/doc.eo
@@ -30,4 +30,4 @@
     # Appends child to DOM document.
     [child] > append-child ?
     # Evaluate XPath expression.
-    [xpath] > evaluate ?
+    [xpath return] > evaluate ?

--- a/src/main/eo/org/eolang/dom/doc.eo
+++ b/src/main/eo/org/eolang/dom/doc.eo
@@ -29,3 +29,5 @@
     [lname] > create-element ?
     # Appends child to DOM document.
     [child] > append-child ?
+    # Evaluate XPath expression.
+    [xpath] > evaluate ?

--- a/src/main/eo/org/eolang/dom/doc.eo
+++ b/src/main/eo/org/eolang/dom/doc.eo
@@ -30,4 +30,11 @@
     # Appends child to DOM document.
     [child] > append-child ?
     # Evaluate XPath expression.
+    # `xpath` - XPath expression.
+    # `return` - Return type, possible data types:
+    # `string` - Node result with `text()` node inside.
+    # `number` - Number result.
+    # `boolean` - Boolean result.
+    # `node` - Single node result as XML element.
+    # `nodeset` - Multiple node results as collection of XML elements.
     [xpath return] > evaluate ?

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOevaluate.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOevaluate.java
@@ -23,7 +23,9 @@ import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
  * Evaluate XPath expression on given document.
@@ -52,35 +54,34 @@ public final class EOdoc$EOxml$EOevaluate extends PhDefault implements Atom {
         types.put("STRING", XPathConstants.STRING);
         types.put("NODE", XPathConstants.NODE);
         types.put("NODESET", XPathConstants.NODESET);
-        types.put("NUMBER", XPathConstants.NUMBER);
         final QName rtype = types.get(
             new Dataized(this.take("return")).asString().toUpperCase(Locale.ROOT)
         );
         final Phi result;
+        final Document doc = new XmlNode.Default(source).self().getOwnerDocument();
         if (XPathConstants.NODE.equals(rtype)) {
             result = Phi.Φ.take("org.eolang.dom.element").take("serialized").copy();
             final byte[] data = new XmlNode.Default(
                 (Element) xpath.evaluate(
                     new Dataized(this.take("xpath")).asString(),
-                    new XmlNode.Default(source).self().getOwnerDocument(),
+                    doc,
                     XPathConstants.NODE
                 )
             ).asString().getBytes();
             result.put("src", new Data.ToPhi(data));
             result.put("parent", new Data.ToPhi(data));
-//            System.out.println(
-//                xpath.evaluate(
-//                    new Dataized(this.take("xpath")).asString(),
-//                    new XmlNode.Default(source).self().getOwnerDocument(),
-//                    XPathConstants.NODE
-//                )
-//            );
-//            Phi.Φ.take("org.eolang.dom.element");
+        } else if(XPathConstants.NODESET.equals(rtype)) {
+            result = new NodesCollection(
+                (NodeList)
+                    xpath.evaluate(
+                        new Dataized(this.take("xpath")).asString(), doc, XPathConstants.NODESET
+                    )
+            ).value();
         } else {
             result = new Data.ToPhi(
                 xpath.evaluate(
                     new Dataized(this.take("xpath")).asString(),
-                    new XmlNode.Default(source).self().getOwnerDocument(),
+                    doc,
                     XPathConstants.STRING
                 )
             );

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOevaluate.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOevaluate.java
@@ -51,7 +51,9 @@ public final class EOdoc$EOxml$EOevaluate extends PhDefault implements Atom {
         final String source = new Dataized(this.take(Attr.RHO).take("serialized")).asString();
         final XPath xpath = XPathFactory.newInstance().newXPath();
         final Map<String, QName> types = new HashMap<>(0);
+        types.put("NUMBER", XPathConstants.NUMBER);
         types.put("STRING", XPathConstants.STRING);
+        types.put("BOOLEAN", XPathConstants.BOOLEAN);
         types.put("NODE", XPathConstants.NODE);
         types.put("NODESET", XPathConstants.NODESET);
         final QName rtype = types.get(
@@ -82,7 +84,7 @@ public final class EOdoc$EOxml$EOevaluate extends PhDefault implements Atom {
                 xpath.evaluate(
                     new Dataized(this.take("xpath")).asString(),
                     doc,
-                    XPathConstants.STRING
+                    rtype
                 )
             );
         }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOevaluate.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOevaluate.java
@@ -8,6 +8,11 @@
  */
 package EOorg.EOeolang.EOdom; // NOPMD
 
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import javax.xml.namespace.QName;
+import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 import org.eolang.AtVoid;
@@ -18,6 +23,7 @@ import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
+import org.w3c.dom.Element;
 
 /**
  * Evaluate XPath expression on given document.
@@ -35,17 +41,50 @@ public final class EOdoc$EOxml$EOevaluate extends PhDefault implements Atom {
     @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public EOdoc$EOxml$EOevaluate() {
         this.add("xpath", new AtVoid("xpath"));
+        this.add("return", new AtVoid("return"));
     }
 
     @Override
     public Phi lambda() throws Exception {
         final String source = new Dataized(this.take(Attr.RHO).take("serialized")).asString();
-        return new Data.ToPhi(
-            XPathFactory.newInstance().newXPath().evaluate(
-                new Dataized(this.take("xpath")).asString(),
-                new XmlNode.Default(source).self().getOwnerDocument(),
-                XPathConstants.STRING
-            )
+        final XPath xpath = XPathFactory.newInstance().newXPath();
+        final Map<String, QName> types = new HashMap<>(0);
+        types.put("STRING", XPathConstants.STRING);
+        types.put("NODE", XPathConstants.NODE);
+        types.put("NODESET", XPathConstants.NODESET);
+        types.put("NUMBER", XPathConstants.NUMBER);
+        final QName rtype = types.get(
+            new Dataized(this.take("return")).asString().toUpperCase(Locale.ROOT)
         );
+        final Phi result;
+        if (XPathConstants.NODE.equals(rtype)) {
+            result = Phi.Φ.take("org.eolang.dom.element").take("serialized").copy();
+            final byte[] data = new XmlNode.Default(
+                (Element) xpath.evaluate(
+                    new Dataized(this.take("xpath")).asString(),
+                    new XmlNode.Default(source).self().getOwnerDocument(),
+                    XPathConstants.NODE
+                )
+            ).asString().getBytes();
+            result.put("src", new Data.ToPhi(data));
+            result.put("parent", new Data.ToPhi(data));
+//            System.out.println(
+//                xpath.evaluate(
+//                    new Dataized(this.take("xpath")).asString(),
+//                    new XmlNode.Default(source).self().getOwnerDocument(),
+//                    XPathConstants.NODE
+//                )
+//            );
+//            Phi.Φ.take("org.eolang.dom.element");
+        } else {
+            result = new Data.ToPhi(
+                xpath.evaluate(
+                    new Dataized(this.take("xpath")).asString(),
+                    new XmlNode.Default(source).self().getOwnerDocument(),
+                    XPathConstants.STRING
+                )
+            );
+        }
+        return result;
     }
 }

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOevaluate.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOevaluate.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOdom; // NOPMD
+
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import org.eolang.AtVoid;
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * Evaluate XPath expression on given document.
+ *
+ * @checkstyle TypeNameCheck (5 lines)
+ * @since 0.0.0
+ */
+@SuppressWarnings("PMD.AvoidDollarSigns")
+@XmirObject(oname = "doc.xml.evaluate")
+public final class EOdoc$EOxml$EOevaluate extends PhDefault implements Atom {
+
+    /**
+     * Ctor.
+     */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+    public EOdoc$EOxml$EOevaluate() {
+        this.add("xpath", new AtVoid("xpath"));
+    }
+
+    @Override
+    public Phi lambda() throws Exception {
+        final String source = new Dataized(this.take(Attr.RHO).take("serialized")).asString();
+        return new Data.ToPhi(
+            XPathFactory.newInstance().newXPath().evaluate(
+                new Dataized(this.take("xpath")).asString(),
+                new XmlNode.Default(source).self().getOwnerDocument(),
+                XPathConstants.STRING
+            )
+        );
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOevaluate.java
+++ b/src/main/java/EOorg/EOeolang/EOdom/EOdoc$EOxml$EOevaluate.java
@@ -30,8 +30,8 @@ import org.w3c.dom.NodeList;
 /**
  * Evaluate XPath expression on given document.
  *
- * @checkstyle TypeNameCheck (5 lines)
  * @since 0.0.0
+ * @checkstyle TypeNameCheck (5 lines)
  */
 @SuppressWarnings("PMD.AvoidDollarSigns")
 @XmirObject(oname = "doc.xml.evaluate")
@@ -48,7 +48,6 @@ public final class EOdoc$EOxml$EOevaluate extends PhDefault implements Atom {
 
     @Override
     public Phi lambda() throws Exception {
-        final String source = new Dataized(this.take(Attr.RHO).take("serialized")).asString();
         final XPath xpath = XPathFactory.newInstance().newXPath();
         final Map<String, QName> types = new HashMap<>(0);
         types.put("NUMBER", XPathConstants.NUMBER);
@@ -59,30 +58,26 @@ public final class EOdoc$EOxml$EOevaluate extends PhDefault implements Atom {
         final QName rtype = types.get(
             new Dataized(this.take("return")).asString().toUpperCase(Locale.ROOT)
         );
+        final Document doc = new XmlNode.Default(
+            new Dataized(this.take(Attr.RHO).take("serialized")).asString()
+        ).self().getOwnerDocument();
         final Phi result;
-        final Document doc = new XmlNode.Default(source).self().getOwnerDocument();
+        final String expression = new Dataized(this.take("xpath")).asString();
         if (XPathConstants.NODE.equals(rtype)) {
             result = Phi.Φ.take("org.eolang.dom.element").take("serialized").copy();
             final byte[] data = new XmlNode.Default(
-                (Element) xpath.evaluate(
-                    new Dataized(this.take("xpath")).asString(),
-                    doc,
-                    XPathConstants.NODE
-                )
+                (Element) xpath.evaluate(expression, doc, XPathConstants.NODE)
             ).asString().getBytes();
             result.put("src", new Data.ToPhi(data));
             result.put("parent", new Data.ToPhi(data));
-        } else if(XPathConstants.NODESET.equals(rtype)) {
+        } else if (XPathConstants.NODESET.equals(rtype)) {
             result = new NodesCollection(
-                (NodeList)
-                    xpath.evaluate(
-                        new Dataized(this.take("xpath")).asString(), doc, XPathConstants.NODESET
-                    )
+                (NodeList) xpath.evaluate(expression, doc, XPathConstants.NODESET)
             ).value();
         } else {
             result = new Data.ToPhi(
                 xpath.evaluate(
-                    new Dataized(this.take("xpath")).asString(),
+                    expression,
                     doc,
                     rtype
                 )

--- a/src/test/eo/org/eolang/dom/doc-tests.eo
+++ b/src/test/eo/org/eolang/dom/doc-tests.eo
@@ -103,3 +103,49 @@ eq. > creates-element
     .parent-node
     .get-attribute "oneway"
     "maybe"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > evaluates-xpath-as-string
+  dom-parser.parse-from-string > doc
+    "<objects><o name='f' base='Q.org.eolang.string'/><o base='Q.org.eolang.f'/></objects>"
+  eq. > @
+    doc.evaluate "//o[1]/@name" "string"
+    "f"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > evaluates-xpath-as-number
+  dom-parser.parse-from-string > doc
+    "<objects><o name='f' base='Q.org.eolang.string'/><o line='222' base='Q.org.eolang.f'/></objects>"
+  eq. > @
+    doc.evaluate "//o[2]/@line" "number"
+    222
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > evaluates-xpath-as-bool
+  dom-parser.parse-from-string > doc
+    "<objects><o name='f' base='Q.org.eolang.string'/><o base='Q.org.eolang.f'/></objects>"
+  eq. > @
+    doc.evaluate "//o[2][starts-with(@base, 'Q.org.eolang')]" "boolean"
+    true
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > evaluates-xpath-as-node
+  dom-parser.parse-from-string > doc
+    "<objects><o name='a' base='Q.org.eolang.f'/><o name='b' base='Q.org.eolang.f'/><o name='c' base='Q.org.eolang.string'/></objects>"
+  eq. > @
+    doc.evaluate
+      "//o[@name='c']"
+      "node"
+    .get-attribute "base"
+    "Q.org.eolang.string"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > evaluates-xpath-as-nodeset
+  dom-parser.parse-from-string > doc
+    "<objects><o name='a' base='Q.org.eolang.f'/><o name='b' base='Q.org.eolang.f'/><o name='c' base='Q.org.eolang.string'/></objects>"
+  eq. > @
+    doc.evaluate
+      "//o[@base='Q.org.eolang.f']"
+      "nodeset"
+    .length
+    2

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -350,6 +350,34 @@ final class EOdocTest {
         );
     }
 
+    @Test
+    void evaluatesXpathAsNumber() {
+        final Phi evaluate = this.parsedDocument(
+            "<books><book id='2' author='Justin Zobel'/><book id='1' author='David West'/></books>"
+        ).take("evaluate");
+        evaluate.put("xpath", new Data.ToPhi("//book[@author='David West']/@id"));
+        evaluate.put("return", new Data.ToPhi("number"));
+        MatcherAssert.assertThat(
+            "Retrieved number does not match with expected",
+            new Dataized(evaluate).asNumber().intValue(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void evaluatesXpathAsBoolean() {
+        final Phi evaluate = this.parsedDocument(
+            "<objects><o name='Q.org.eolang.f'/></objects>"
+        ).take("evaluate");
+        evaluate.put("xpath", new Data.ToPhi("//o[1][starts-with(@name, 'Q.org.eolang')]"));
+        evaluate.put("return", new Data.ToPhi("boolean"));
+        MatcherAssert.assertThat(
+            "Retrieved boolean value does not match with expected",
+            new Dataized(evaluate).asBool(),
+            Matchers.equalTo(true)
+        );
+    }
+
     private Phi parsedDocument(final String data) {
         final Phi parse = Phi.Φ.take("org.eolang.dom.dom-parser").copy()
             .take("parse-from-string");

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -305,6 +305,7 @@ final class EOdocTest {
             "<books><book id='1' title='EO vol.3'/><book id='2' title='How to Write a Better Thesis'/></books>"
         ).take("evaluate");
         evaluate.put("xpath", new Data.ToPhi("//book[@id='2']/@title"));
+        evaluate.put("return", new Data.ToPhi("string"));
         final String result = new Dataized(
             evaluate
         ).asString();
@@ -332,6 +333,20 @@ final class EOdocTest {
             Matchers.equalTo(
                 new Xembler(new Directives().add("blog").attr("id", "2").set("l3r8y.ru")).xml()
             )
+        );
+    }
+
+    @Test
+    void evaluatesXpathAsNodeSet() {
+        final Phi evaluate = this.parsedDocument(
+            "<objects><o base='f'/><o base='f'/><o base='a'/></objects>"
+        ).take("evaluate");
+        evaluate.put("xpath", new Data.ToPhi("//o[@base='f']"));
+        evaluate.put("return", new Data.ToPhi("nodeset"));
+        MatcherAssert.assertThat(
+            "Resulted node does not match with expected",
+            new Dataized(evaluate.take("length")).asNumber().intValue(),
+            Matchers.equalTo(2)
         );
     }
 

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -319,6 +319,22 @@ final class EOdocTest {
         );
     }
 
+    @Test
+    void evaluatesXpathAsNode() throws ImpossibleModificationException {
+        final Phi evaluate = this.parsedDocument(
+            "<blogs><blog id='1'>yegor256.com</blog><blog id='2'>l3r8y.ru</blog><blog id='3'>h1alexbel.xyz</blog></blogs>"
+        ).take("evaluate");
+        evaluate.put("xpath", new Data.ToPhi("//blog[@id='2']"));
+        evaluate.put("return", new Data.ToPhi("node"));
+        MatcherAssert.assertThat(
+            "Resulted node does not match with expected",
+            new Dataized(evaluate.take("as-string")).asString(),
+            Matchers.equalTo(
+                new Xembler(new Directives().add("blog").attr("id", "2").set("l3r8y.ru")).xml()
+            )
+        );
+    }
+
     private Phi parsedDocument(final String data) {
         final Phi parse = Phi.Φ.take("org.eolang.dom.dom-parser").copy()
             .take("parse-from-string");

--- a/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
+++ b/src/test/java/EOorg/EOeolang/EOdom/EOdocTest.java
@@ -299,6 +299,26 @@ final class EOdocTest {
         );
     }
 
+    @Test
+    void evaluatesXpath() {
+        final Phi evaluate = this.parsedDocument(
+            "<books><book id='1' title='EO vol.3'/><book id='2' title='How to Write a Better Thesis'/></books>"
+        ).take("evaluate");
+        evaluate.put("xpath", new Data.ToPhi("//book[@id='2']/@title"));
+        final String result = new Dataized(
+            evaluate
+        ).asString();
+        final String expected = "How to Write a Better Thesis";
+        MatcherAssert.assertThat(
+            String.format(
+                "Result of XPath evaluation: '%s' does not match with expected: '%s'",
+                result, expected
+            ),
+            result,
+            Matchers.equalTo(expected)
+        );
+    }
+
     private Phi parsedDocument(final String data) {
         final Phi parse = Phi.Φ.take("org.eolang.dom.dom-parser").copy()
             .take("parse-from-string");


### PR DESCRIPTION
In this PR I've implemented `doc.evaluate` object for XPath evaluation.

closes #53
History:
- **feat(#53): evaluates XPath**
- **feat(#53): evaluates as node**
- **feat(#53): evaluates as nodeset**
- **feat(#53): evaluates as number, bool**
- **feat(#53): EO tests**
- **feat(#53): clean for qulice**
- **feat(#53): docs**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the functionality to evaluate XPath expressions on XML documents within the `EOdoc` class. It adds methods to return results in various types, including string, number, boolean, node, and nodeset. Additionally, unit tests for these functionalities are implemented.

### Detailed summary
- Added `evaluate` method in `EOdoc$EOxml$EOevaluate` for XPath evaluation.
- Supported return types: `string`, `number`, `boolean`, `node`, and `nodeset`.
- Created unit tests in `doc-tests.eo` for evaluating XPath as different types.
- Added tests in `EOdocTest.java` to verify XPath evaluations against expected outcomes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->